### PR TITLE
feature: add the function show_alloc_mem and fix the realloc bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CFLAGS = -Wall -Wextra -g3
 
 SRCS_DIR = srcs/
 
-SRCS = $(addprefix srcs/, main.c malloc.c free.c utils.c realloc.c calloc.c)
+SRCS = $(addprefix srcs/, main.c malloc.c free.c utils.c realloc.c calloc.c show_alloc_mem.c)
 
 OBJS_DIR = .objs/
 

--- a/includes/lib_malloc.h
+++ b/includes/lib_malloc.h
@@ -1,5 +1,5 @@
-#ifndef FT_MALLOC_H
-# define FT_MALLOC_H
+#ifndef LIB_MALLOC_H
+# define LIB_MALLOC_H
 
 # include <sys/mman.h>
 # include <unistd.h>
@@ -8,4 +8,5 @@ void	free(void *ptr);
 void	*malloc(size_t size);
 void	*realloc(void *ptr, size_t size);
 void	*calloc(size_t nmemb, size_t size);
+void	show_alloc_mem(void);
 #endif

--- a/includes/malloc_internal.h
+++ b/includes/malloc_internal.h
@@ -52,26 +52,26 @@ typedef struct s_block
 
 typedef struct s_page
 {
-	size_t		length;
-	t_block *blocks; // pointe vers le premier block de la page
-	size_t		nb_block_free;
-	struct s_page *next; // pointe vers la prochaine page
-}				t_page;
+	size_t			length;
+	t_block			*blocks; // pointe vers le premier block de la page
+	size_t			nb_block_free;
+	struct s_page	*next; // pointe vers la prochaine page
+}					t_page;
 
 typedef struct s_malloc
 {
-	t_page *tiny;  // page liee au tiny malloc
-	t_page *small; // page liee au small malloc
-	t_page *large; // page liee au large malloc
-}				t_malloc;
+	t_page			*tiny;  // page liee au tiny malloc
+	t_page			*small; // page liee au small malloc
+	t_page			*large; // page liee au large malloc
+}					t_malloc;
 
 extern t_malloc	g_malloc;
 
-t_block			*page_find_block_by_ptr(t_page *page, void *ptr,
-					t_block **prev_out);
-void			initialize_blocks(t_block **block, size_t size);
-int				split_block(t_block *block, size_t size);
-t_page			*find_page_by_block(t_page *pages, t_block *block);
-t_block			*find_block(t_page *pages, void *ptr);
-
+t_block				*page_find_block_by_ptr(t_page *page, void *ptr,
+						t_block **prev_out);
+void				initialize_blocks(t_block **block, size_t size);
+int					split_block(t_block *block, size_t size);
+t_page				*find_page_by_block(t_page *pages, t_block *block);
+t_block				*find_block(t_page *pages, void *ptr);
+int					merge_block(t_block *block, t_block *prev_block);
 #endif

--- a/libft/printf_OK/ft_printf.h
+++ b/libft/printf_OK/ft_printf.h
@@ -6,7 +6,7 @@
 /*   By: madamou <madamou@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/25 15:12:26 by itahri            #+#    #+#             */
-/*   Updated: 2025/09/03 04:30:21 by madamou          ###   ########.fr       */
+/*   Updated: 2025/09/05 00:01:42 by madamou          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,6 +23,7 @@ void	ft_putnbr_base(long long int nbr, char *base);
 int		ft_printf(const char *format, ...);
 int		monitoring(va_list args, char *c);
 
+void	print_mem(unsigned long long int nbr);
 int		hex_fr(va_list args, int cas);
 int		car_fr(va_list args);
 int		mem_fr(va_list args);

--- a/libft/printf_OK/mem_fr.c
+++ b/libft/printf_OK/mem_fr.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   mem_fr.c                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: itahri <itahri@contact.42.fr>              +#+  +:+       +#+        */
+/*   By: madamou <madamou@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/25 16:11:38 by itahri            #+#    #+#             */
-/*   Updated: 2024/05/25 22:27:57 by itahri           ###   ########.fr       */
+/*   Updated: 2025/09/05 00:01:28 by madamou          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,7 +24,7 @@ static void	ft_putnbr_base_ptr(unsigned long long int nbr, char *base)
 	write(1, &char_nbr, 1);
 }
 
-static void	print_mem(unsigned long long int nbr)
+void	print_mem(unsigned long long int nbr)
 {
 	write(1, "0x", 2);
 	ft_putnbr_base_ptr(nbr, "0123456789abcdef");

--- a/srcs/free.c
+++ b/srcs/free.c
@@ -1,44 +1,14 @@
 #include "../includes/malloc_internal.h"
 
-void	block_merge_with_next(t_block *first, t_block *second)
-{
-	size_t total_size;
-
-	total_size = GET_BLOCK_SIZE(first) + BLOCK_HEADER_SIZE + GET_BLOCK_SIZE(second);
-
-	SET_BLOCK_SIZE(first, total_size);
-	if (IS_BLOCK_LAST(second))
-		SET_BLOCK_LAST(first);
-}
-
-void block_free(t_block *block)
+void	block_free(t_block *block)
 {
 	if (IS_BLOCK_FREE(block) == true)
 	{
 		ft_putendl_fd("free(): double free detected in tcache 2",
-						STDERR_FILENO);
+			STDERR_FILENO);
 		abort();
 	}
 	SET_BLOCK_FREE(block);
-}
-
-int merge_block(t_block *block, t_block *prev_block) {
-	int	nb_merge;
-	t_block *next_block;
-
-	nb_merge = 0;
-	next_block = NEXT_BLOCK(block);
-	if (next_block && IS_BLOCK_FREE(next_block) == true)
-	{
-		block_merge_with_next(block, next_block);
-		nb_merge++;
-	}
-	if (prev_block && IS_BLOCK_FREE(prev_block) == true)
-	{
-		block_merge_with_next(prev_block, block);
-		nb_merge++;
-	}
-	return nb_merge;
 }
 
 void	remove_page(t_page **pages_list, t_page *page)
@@ -72,7 +42,8 @@ int	free_block_from_zone(t_page **pages_list, void *ptr)
 			block_free(block);
 			if (merge_block(block, prev_block) == 0)
 				current_page->nb_block_free++;
-			if (IS_BLOCK_LAST(current_page->blocks) && IS_BLOCK_FREE(current_page->blocks) == true)
+			if (IS_BLOCK_LAST(current_page->blocks)
+				&& IS_BLOCK_FREE(current_page->blocks) == true)
 				remove_page(pages_list, current_page);
 			return (1);
 		}
@@ -107,7 +78,7 @@ void	free(void *ptr)
 	if (free_block_from_zone(&g_malloc.small, ptr))
 		return ;
 	if (free_large_block(ptr))
-		return;
+		return ;
 	ft_putendl_fd("free(): invalid pointer", STDERR_FILENO);
 	abort();
 }

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -9,6 +9,7 @@ int main(void)
         perror("malloc failed");
         return 1;
     }
+	show_alloc_mem();
     strcpy(msg, "Hello malloc!");
     printf("msg = %s\n", msg);
 
@@ -19,6 +20,8 @@ int main(void)
         free(msg); // free old if realloc failed
         return 1;
     }
+	show_alloc_mem();
+
     strcat(bigger, " + realloc works!");
     printf("bigger = %s\n", bigger);
 
@@ -29,11 +32,15 @@ int main(void)
         free(bigger);
         return 1;
     }
+	show_alloc_mem();
+
     printf("smaller (truncated) = %.*s\n", 9, smaller);
 
     printf("\n=== TEST FREE ===\n");
     free(smaller);
     printf("Memory freed successfully!\n");
+
+	show_alloc_mem();
 
     printf("=== TEST LARGE MALLOCS (> 1024 bytes) ===\n");
 
@@ -44,6 +51,8 @@ int main(void)
         perror("malloc large1 failed");
         return 1;
     }
+	show_alloc_mem();
+	
     memset(large1, 'A', big_size - 1);
     large1[big_size - 1] = '\0';
     printf("large1 allocated (%zu bytes): first char = %c, last char = %c\n",

--- a/srcs/realloc.c
+++ b/srcs/realloc.c
@@ -25,6 +25,7 @@ void	*shrink_memory(t_page *pages, size_t size, t_block *block)
 	return (GET_BLOCK_PTR(block));
 }
 
+// TODO parfois pas besoin de toucher au block suivant
 int	increase_memory(t_page *pages, t_block *block, size_t size)
 {
 	size_t	new_size;
@@ -44,7 +45,7 @@ int	increase_memory(t_page *pages, t_block *block, size_t size)
 		return (0);
 	new_size = total - size - BLOCK_HEADER_SIZE;
 	SET_BLOCK_SIZE(block, size);
-	new_free_block = (void *)block + GET_BLOCK_SIZE(block);
+	new_free_block = (void *)block + BLOCK_HEADER_SIZE + size;
 	memmove(new_free_block, next_block, BLOCK_HEADER_SIZE);
 	SET_BLOCK_SIZE(new_free_block, new_size);
 	current_page = find_page_by_block(pages, block);

--- a/srcs/show_alloc_mem.c
+++ b/srcs/show_alloc_mem.c
@@ -1,0 +1,69 @@
+#include "../includes/malloc_internal.h"
+#include <stddef.h>
+
+size_t	show_block_infos(t_block *block)
+{
+	void	*begin;
+	size_t	size;
+
+	begin = GET_BLOCK_PTR(block);
+	size = GET_BLOCK_SIZE(block);
+	print_mem((unsigned long long int)begin);
+	ft_putstr(" - ");
+	print_mem((unsigned long long int)begin + size);
+	ft_putstr(" : ");
+	ft_putnbr(size);
+	if (IS_BLOCK_FREE(block))
+		ft_putstr(" free");
+	ft_putendl(" bytes");
+	return (size);
+}
+
+size_t	block_infos(t_page *page)
+{
+	t_block	*current_block;
+	size_t	total;
+
+	current_block = page->blocks;
+	total = 0;
+	while (current_block)
+	{
+		total += show_block_infos(current_block);
+		current_block = NEXT_BLOCK(current_block);
+	}
+	return (total);
+}
+
+size_t	show_mem(t_page *malloc_page, char *mem_zone)
+{
+	t_page	*current_page;
+	size_t	total;
+
+	total = 0;
+	current_page = malloc_page;
+	while (current_page)
+	{
+		ft_putstr(mem_zone);
+		ft_putstr(" : ");
+		print_mem((unsigned long long int)GET_BLOCK_PTR(current_page->blocks));
+		ft_putstr("\n");
+		total += block_infos(current_page);
+		current_page = current_page->next;
+	}
+	return (total);
+}
+
+void	show_alloc_mem(void)
+{
+	size_t	total;
+
+	total = 0;
+	ft_putendl("-----------------show_alloc_mem-----------------");
+	total += show_mem(g_malloc.tiny, "TINY");
+	total += show_mem(g_malloc.small, "SMALL");
+	total += show_mem(g_malloc.large, "LARGE");
+	ft_putstr("Total : ");
+	ft_putnbr(total);
+	ft_putendl(" bytes");
+	ft_putendl("------------------------------------------------");
+}


### PR DESCRIPTION
Added the show_alloc_mem function to display detailed information about current memory allocations.
It prints the memory zones (TINY, SMALL, LARGE), each block’s start and end addresses, size, and whether it is free or in use.
Also included a total memory usage summary to help with debugging and memory management visualization.
Fix a realloc bug