### PR TITLE
Change/true size

### DIFF
--- a/includes/malloc_internal.h
+++ b/includes/malloc_internal.h
@@ -15,28 +15,27 @@
 // arrondir un nombre au multiple de 8 superieur pour l'alignement
 # define ALIGN(x) (((x) + (MEMORY_ALIGNMENT - 1)) & ~(MEMORY_ALIGNMENT - 1))
 
-# define BLOCK_FREE (1 << 0) // flag pour le free
-# define BLOCK_LAST (1 << 1) // flag pour le dernier block
+# define BLOCK_FREE 0 // flag pour le free
+# define BLOCK_LAST 1 // flag pour le dernier block
 
-# define SET_BLOCK_FREE(block) ((block)->metadata |= BLOCK_FREE)
+# define SET_BLOCK_FREE(block) ((block)->metadata[BLOCK_FREE] = true)
 // mettre le block comme free
-# define SET_BLOCK_USE(block) ((block)->metadata &= ~BLOCK_FREE)
+# define SET_BLOCK_USE(block) ((block)->metadata[BLOCK_FREE] = false)
 // mettre le block comme utilise
-# define IS_BLOCK_FREE(block) ((block)->metadata & BLOCK_FREE)
+# define IS_BLOCK_FREE(block) ((block)->metadata[BLOCK_FREE])
 // savoir si le block est free
 
-# define SET_BLOCK_LAST(block) ((block)->metadata |= BLOCK_LAST)
+# define SET_BLOCK_LAST(block) ((block)->metadata[BLOCK_LAST] = true)
 // mettre le block comme le dernier block
-# define SET_BLOCK_NOT_LAST(block) ((block)->metadata &= ~BLOCK_LAST)
+# define SET_BLOCK_NOT_LAST(block) ((block)->metadata[BLOCK_LAST] = false)
 // mettre le block comme n'est pas le dernier block
-# define IS_BLOCK_LAST(block) ((block)->metadata & BLOCK_LAST)
+# define IS_BLOCK_LAST(block) ((block)->metadata[BLOCK_LAST])
 // savoir si le block est le dernier block de la page
 
-# define GET_BLOCK_SIZE(block) ((block)->metadata & ~7)
+# define GET_BLOCK_SIZE(block) ((block)->size)
 // avoir la taille du block
 // size need to be aligned !!
-# define SET_BLOCK_SIZE(block, size) \
-	((block)->metadata = (size & ~7) | ((block)->metadata & 7))
+# define SET_BLOCK_SIZE(block, sz) ((block)->size = sz)
 // set la taille du block
 
 # define NEXT_BLOCK(block) \
@@ -47,7 +46,8 @@
 
 typedef struct s_block
 {
-	size_t		metadata;
+	unsigned int size;
+	char		metadata[4];
 }				t_block;
 
 typedef struct s_page

--- a/includes/malloc_internal.h
+++ b/includes/malloc_internal.h
@@ -32,7 +32,7 @@
 # define IS_BLOCK_LAST(block) ((block)->metadata[BLOCK_LAST])
 // savoir si le block est le dernier block de la page
 
-# define GET_BLOCK_SIZE(block) ((block)->size)
+# define GET_BLOCK_SIZE(block) (ALIGN((block)->size))
 // avoir la taille du block
 // size need to be aligned !!
 # define SET_BLOCK_SIZE(block, sz) ((block)->size = sz)

--- a/srcs/calloc.c
+++ b/srcs/calloc.c
@@ -2,12 +2,10 @@
 
 void	*calloc(size_t nmemb, size_t size)
 {
-	size_t	aligned_size;
 	void	*ptr;
 
-	aligned_size = ALIGN((nmemb * size));
-	ptr = malloc(aligned_size);
+	ptr = malloc(nmemb * size);
 	if (ptr)
-		bzero(ptr, aligned_size);
+		bzero(ptr, size);
 	return (ptr);
 }

--- a/srcs/calloc.c
+++ b/srcs/calloc.c
@@ -8,6 +8,6 @@ void	*calloc(size_t nmemb, size_t size)
 	aligned_size = ALIGN((nmemb * size));
 	ptr = malloc(aligned_size);
 	if (ptr)
-		ft_bzero(ptr, aligned_size);
+		bzero(ptr, aligned_size);
 	return (ptr);
 }

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -1,131 +1,498 @@
 #include "../includes/lib_malloc.h"
 # include "../libft/printf_OK/ft_printf.h"
 
-int main(void)
-{
-    printf("=== TEST MALLOC ===\n");
-    char *msg = (char *)malloc(20);
-    if (!msg) {
-        perror("malloc failed");
-        return 1;
-    }
-	show_alloc_mem();
-    strcpy(msg, "Hello malloc!");
-    printf("msg = %s\n", msg);
 
-    printf("\n=== TEST REALLOC (expand) ===\n");
-    char *bigger = (char *)realloc(msg, 40); // agrandir
-    if (!bigger) {
-        perror("realloc failed");
-        free(msg); // free old if realloc failed
-        return 1;
-    }
-	show_alloc_mem();
+// Couleurs pour les tests
+#define GREEN "\033[32m"
+#define RED "\033[31m"
+#define YELLOW "\033[33m"
+#define BLUE "\033[34m"
+#define RESET "\033[0m"
 
-    strcat(bigger, " + realloc works!");
-    printf("bigger = %s\n", bigger);
+#define TEST_SECTION(msg) printf(BLUE "\n=== " msg " ===" RESET "\n")
 
-    printf("\n=== TEST REALLOC (shrink) ===\n");
-    char *smaller = (char *)realloc(bigger, 10); // réduire
-    if (!smaller) {
-        perror("realloc failed");
-        free(bigger);
-        return 1;
-    }
-	show_alloc_mem();
+// Variables globales pour les statistiques
+static int tests_passed = 0;
+static int tests_failed = 0;
 
-    printf("smaller (truncated) = %.*s\n", 9, smaller);
-
-    printf("\n=== TEST FREE ===\n");
-    free(smaller);
-    printf("Memory freed successfully!\n");
-
-	show_alloc_mem();
-
-    printf("=== TEST LARGE MALLOCS (> 1024 bytes) ===\n");
-
-    // 1. Allocation simple d’un large bloc
-    size_t big_size = 2048; // > 1024 donc doit aller dans large malloc
-    char *large1 = (char *)malloc(big_size);
-    if (!large1) {
-        perror("malloc large1 failed");
-        return 1;
-    }
-	show_alloc_mem();
-	
-    memset(large1, 'A', big_size - 1);
-    large1[big_size - 1] = '\0';
-    printf("large1 allocated (%zu bytes): first char = %c, last char = %c\n",
-           big_size, large1[0], large1[big_size - 2]);
-
-    // 2. Realloc to a larger size (should trigger a new mmap)
-    size_t bigger_size = 4096;
-    char *large2 = (char *)realloc(large1, bigger_size);
-    if (!large2) {
-        perror("realloc large2 failed");
-        free(large1);
-        return 1;
-    }
-    memset(large2 + big_size, 'B', bigger_size - big_size - 1);
-    large2[bigger_size - 1] = '\0';
-    printf("large2 reallocated (%zu bytes): mid char = %c, last char = %c\n",
-           bigger_size, large2[big_size], large2[bigger_size - 2]);
-
-    // 3. Realloc to a smaller size (should shrink)
-    size_t smaller_size = 1500; // still > 1024, still large
-    char *large3 = (char *)realloc(large2, smaller_size);
-    if (!large3) {
-        perror("realloc large3 failed");
-        free(large2);
-        return 1;
-    }
-    printf("large3 reallocated smaller (%zu bytes): first char = %c\n",
-           smaller_size, large3[0]);
-
-    // 4. Free the large block
-    free(large3);
-    printf("large3 freed successfully.\n");
-
-    // 5. Edge case: allocation juste au-dessus du seuil
-    char *edge = (char *)malloc(1025);
-    if (!edge) {
-        perror("malloc edge failed");
-        return 1;
-    }
-    printf("edge allocated (1025 bytes): OK\n");
-    free(edge);
-
-	printf("\n=== TEST ALIGNMENT (8 bytes) ===\n");
-
-    void *a1 = malloc(1);
-    void *a2 = malloc(3);
-    void *a3 = malloc(50);
-    void *a4 = malloc(70);
-
-    printf("malloc(1)  -> %p (should be 8 aligned)\n", a1);
-    printf("malloc(3)  -> %p (should be 8 aligned)\n", a2);
-    printf("malloc(50) -> %p (should be 8 aligned)\n", a3);
-    printf("malloc(70) -> %p (should be 8 aligned)\n", a4);
-
-    if (((uintptr_t)a1 % 8) == 0 &&
-        ((uintptr_t)a2 % 8) == 0 &&
-        ((uintptr_t)a3 % 8) == 0 &&
-        ((uintptr_t)a4 % 8) == 0) {
-        printf("✅ All allocations are 8-byte aligned!\n");
+void test_result(int condition, const char *test_name) {
+    if (condition) {
+        printf(GREEN "✅ PASS: %s" RESET "\n", test_name);
+        tests_passed++;
     } else {
-        printf("❌ Alignment error detected!\n");
+        printf(RED "❌ FAIL: %s" RESET "\n", test_name);
+        tests_failed++;
     }
+}
 
-	show_alloc_mem();
+void test_basic_malloc() {
+    TEST_SECTION("BASIC MALLOC TESTS");
+    
+    // Test 1: malloc(0) - comportement défini par l'implémentation
+    void *p0 = malloc(0);
+    test_result(p0 != NULL || p0 == NULL, "malloc(0) returns valid result");
+    if (p0) free(p0);
+    
+    // Test 2: petites tailles (TINY)
+    char *tiny1 = malloc(1);
+    char *tiny8 = malloc(8);
+    char *tiny16 = malloc(16);
+    char *tiny32 = malloc(32);
+    char *tiny64 = malloc(64);
+    char *tiny128 = malloc(128);
+    
+    test_result(tiny1 != NULL, "malloc(1) succeeds");
+    test_result(tiny8 != NULL, "malloc(8) succeeds");
+    test_result(tiny16 != NULL, "malloc(16) succeeds");
+    test_result(tiny32 != NULL, "malloc(32) succeeds");
+    test_result(tiny64 != NULL, "malloc(64) succeeds");
+    test_result(tiny128 != NULL, "malloc(128) succeeds");
+    
+    // Test d'alignement (8 bytes)
+    test_result(((uintptr_t)tiny1 % 8) == 0, "malloc(1) is 8-byte aligned");
+    test_result(((uintptr_t)tiny8 % 8) == 0, "malloc(8) is 8-byte aligned");
+    test_result(((uintptr_t)tiny16 % 8) == 0, "malloc(16) is 8-byte aligned");
+    test_result(((uintptr_t)tiny32 % 8) == 0, "malloc(32) is 8-byte aligned");
+    test_result(((uintptr_t)tiny64 % 8) == 0, "malloc(64) is 8-byte aligned");
+    test_result(((uintptr_t)tiny128 % 8) == 0, "malloc(128) is 8-byte aligned");
+    
+    // Test d'écriture/lecture
+    if (tiny32) {
+        strcpy(tiny32, "Hello");
+        test_result(strcmp(tiny32, "Hello") == 0, "Write/read in tiny malloc");
+    }
+    
+    show_alloc_mem();
+    
+    free(tiny1); free(tiny8); free(tiny16); 
+    free(tiny32); free(tiny64); free(tiny128);
+}
 
-    free(a1);
-    free(a2);
-    free(a3);
-    free(a4);
+void test_small_malloc() {
+    TEST_SECTION("SMALL MALLOC TESTS");
+    
+    // Test tailles SMALL (129 à 1024 bytes)
+    char *small200 = malloc(200);
+    char *small400 = malloc(400);
+    char *small600 = malloc(600);
+    char *small800 = malloc(800);
+    char *small1000 = malloc(1000);
+    char *small1024 = malloc(1024); // limite SMALL
+    
+    test_result(small200 != NULL, "malloc(200) succeeds");
+    test_result(small400 != NULL, "malloc(400) succeeds");
+    test_result(small600 != NULL, "malloc(600) succeeds");
+    test_result(small800 != NULL, "malloc(800) succeeds");
+    test_result(small1000 != NULL, "malloc(1000) succeeds");
+    test_result(small1024 != NULL, "malloc(1024) succeeds");
+    
+    // Test d'alignement
+    test_result(((uintptr_t)small200 % 8) == 0, "malloc(200) is 8-byte aligned");
+    test_result(((uintptr_t)small400 % 8) == 0, "malloc(400) is 8-byte aligned");
+    test_result(((uintptr_t)small1024 % 8) == 0, "malloc(1024) is 8-byte aligned");
+    
+    // Test d'écriture dans les blocs
+    if (small400) {
+        memset(small400, 'A', 399);
+        small400[399] = '\0';
+        test_result(small400[0] == 'A' && small400[398] == 'A', "Write/read in small malloc");
+    }
+    
+    show_alloc_mem();
+    
+    free(small200); free(small400); free(small600);
+    free(small800); free(small1000); free(small1024);
+}
 
-    printf("\n=== TEST FREE INVALID ===\n");
-    // Attention : ceci doit provoquer ton abort() custom
-    // free(smaller); // décommenter pour tester le "double free detected"
+void test_large_malloc() {
+    TEST_SECTION("LARGE MALLOC TESTS");
+    
+    // Test tailles LARGE (> 1024 bytes)
+    char *large1025 = malloc(1025); // première taille LARGE
+    char *large2048 = malloc(2048);
+    char *large4096 = malloc(4096);
+    char *large8192 = malloc(8192);
+    char *large16384 = malloc(16384);
+    char *large_huge = malloc(1024 * 1024); // 1MB
+    
+    test_result(large1025 != NULL, "malloc(1025) succeeds");
+    test_result(large2048 != NULL, "malloc(2048) succeeds");
+    test_result(large4096 != NULL, "malloc(4096) succeeds");
+    test_result(large8192 != NULL, "malloc(8192) succeeds");
+    test_result(large16384 != NULL, "malloc(16384) succeeds");
+    test_result(large_huge != NULL, "malloc(1MB) succeeds");
+    
+    // Test d'alignement
+    test_result(((uintptr_t)large1025 % 8) == 0, "malloc(1025) is 8-byte aligned");
+    test_result(((uintptr_t)large2048 % 8) == 0, "malloc(2048) is 8-byte aligned");
+    test_result(((uintptr_t)large_huge % 8) == 0, "malloc(1MB) is 8-byte aligned");
+    
+    // Test d'écriture dans un gros bloc
+    if (large_huge) {
+        large_huge[0] = 'X';
+        large_huge[1024 * 1024 - 1] = 'Y';
+        test_result(large_huge[0] == 'X' && large_huge[1024 * 1024 - 1] == 'Y', 
+                   "Write/read in 1MB malloc");
+    }
+    
+    show_alloc_mem();
+    
+    free(large1025); free(large2048); free(large4096);
+    free(large8192); free(large16384); free(large_huge);
+}
 
-    return 0;
+void test_fragmentation() {
+    TEST_SECTION("FRAGMENTATION TESTS");
+    
+    // Créer de la fragmentation
+    void *ptrs[10];
+    
+    // Allouer 10 blocs
+    for (int i = 0; i < 10; i++) {
+        ptrs[i] = malloc(64);
+        test_result(ptrs[i] != NULL, "Fragmentation malloc succeeds");
+    }
+    
+    show_alloc_mem();
+    
+    // Libérer les blocs impairs (créer des trous)
+    for (int i = 1; i < 10; i += 2) {
+        free(ptrs[i]);
+        ptrs[i] = NULL;
+    }
+    
+    printf("After freeing odd blocks:\n");
+    show_alloc_mem();
+    
+    // Essayer de réallouer dans les trous
+    void *new_ptr = malloc(32); // devrait réutiliser un trou
+    test_result(new_ptr != NULL, "Malloc after fragmentation succeeds");
+    
+    // Nettoyer
+    for (int i = 0; i < 10; i += 2) {
+        free(ptrs[i]);
+    }
+    free(new_ptr);
+}
+
+void test_realloc_tiny_to_tiny() {
+    TEST_SECTION("REALLOC TINY->TINY TESTS");
+    
+    char *ptr = malloc(16);
+    test_result(ptr != NULL, "Initial malloc(16) for realloc");
+    
+    if (ptr) {
+        strcpy(ptr, "Hello");
+        
+        // Agrandir dans TINY
+        ptr = realloc(ptr, 32);
+        test_result(ptr != NULL, "realloc(16->32) succeeds");
+        test_result(strcmp(ptr, "Hello") == 0, "Data preserved in realloc(16->32)");
+        
+        // Réduire dans TINY
+        ptr = realloc(ptr, 8);
+        test_result(ptr != NULL, "realloc(32->8) succeeds");
+        test_result(strncmp(ptr, "Hello", 5) == 0, "Data preserved in realloc(32->8)");
+        
+        free(ptr);
+    }
+}
+
+void test_realloc_small_to_small() {
+    TEST_SECTION("REALLOC SMALL->SMALL TESTS");
+    
+    char *ptr = malloc(200);
+    test_result(ptr != NULL, "Initial malloc(200) for realloc");
+    
+    if (ptr) {
+        memset(ptr, 'A', 199);
+        ptr[199] = '\0';
+        
+        // Agrandir dans SMALL
+        ptr = realloc(ptr, 500);
+        test_result(ptr != NULL, "realloc(200->500) succeeds");
+        test_result(ptr[0] == 'A' && ptr[198] == 'A', "Data preserved in realloc(200->500)");
+        
+        // Réduire dans SMALL
+        ptr = realloc(ptr, 150);
+        test_result(ptr != NULL, "realloc(500->150) succeeds");
+        test_result(ptr[0] == 'A' && ptr[149] == 'A', "Data preserved in realloc(500->150)");
+        
+        free(ptr);
+    }
+}
+
+void test_realloc_large_to_large() {
+    TEST_SECTION("REALLOC LARGE->LARGE TESTS");
+    
+    char *ptr = malloc(2048);
+    test_result(ptr != NULL, "Initial malloc(2048) for realloc");
+    
+    if (ptr) {
+        memset(ptr, 'B', 2047);
+        ptr[2047] = '\0';
+        
+        // Agrandir dans LARGE
+        ptr = realloc(ptr, 4096);
+        test_result(ptr != NULL, "realloc(2048->4096) succeeds");
+        test_result(ptr[0] == 'B' && ptr[2046] == 'B', "Data preserved in realloc(2048->4096)");
+        
+        // Réduire dans LARGE
+        ptr = realloc(ptr, 1500);
+        test_result(ptr != NULL, "realloc(4096->1500) succeeds");
+        test_result(ptr[0] == 'B' && ptr[1499] == 'B', "Data preserved in realloc(4096->1500)");
+        
+        free(ptr);
+    }
+}
+
+void test_realloc_category_changes() {
+    TEST_SECTION("REALLOC CATEGORY CHANGE TESTS");
+    
+    // TINY -> SMALL
+    char *ptr = malloc(64);
+    if (ptr) {
+        strcpy(ptr, "TinyToSmall");
+        ptr = realloc(ptr, 256);
+        test_result(ptr != NULL, "realloc TINY->SMALL succeeds");
+        test_result(strcmp(ptr, "TinyToSmall") == 0, "Data preserved TINY->SMALL");
+        
+        // SMALL -> LARGE
+        strcat(ptr, " and SmallToLarge");
+        ptr = realloc(ptr, 2048);
+        test_result(ptr != NULL, "realloc SMALL->LARGE succeeds");
+        test_result(strstr(ptr, "TinyToSmall") != NULL, "Data preserved SMALL->LARGE");
+        
+        // LARGE -> SMALL
+        ptr = realloc(ptr, 512);
+        test_result(ptr != NULL, "realloc LARGE->SMALL succeeds");
+        test_result(strstr(ptr, "TinyToSmall") != NULL, "Data preserved LARGE->SMALL");
+        
+        // SMALL -> TINY
+        ptr = realloc(ptr, 32);
+        test_result(ptr != NULL, "realloc SMALL->TINY succeeds");
+        test_result(strncmp(ptr, "TinyToSmall", 11) == 0, "Data preserved SMALL->TINY");
+        
+        free(ptr);
+    }
+}
+
+void test_realloc_edge_cases() {
+    TEST_SECTION("REALLOC EDGE CASES");
+    
+    // realloc(NULL, size) = malloc(size)
+    char *ptr = realloc(NULL, 100);
+    test_result(ptr != NULL, "realloc(NULL, 100) works like malloc");
+    if (ptr) {
+        strcpy(ptr, "Realloc NULL test");
+        test_result(strcmp(ptr, "Realloc NULL test") == 0, "Write after realloc(NULL)");
+    }
+    
+    // realloc(ptr, 0) = free(ptr) + return implementation-defined
+    void *result = realloc(ptr, 0);
+    test_result(1, "realloc(ptr, 0) completes without crash");
+    if (result) free(result);
+    
+    // realloc même taille
+    ptr = malloc(100);
+    if (ptr) {
+        strcpy(ptr, "Same size test");
+        char *old_ptr = ptr;
+        ptr = realloc(ptr, 100);
+        test_result(ptr != NULL, "realloc same size succeeds");
+        test_result(strcmp(ptr, "Same size test") == 0, "Data preserved same size realloc");
+        test_result(old_ptr == ptr, "Pointer preserved same size realloc");
+        free(ptr);
+    }
+}
+
+void test_multiple_allocations() {
+    TEST_SECTION("MULTIPLE ALLOCATIONS TEST");
+    
+    const int num_allocs = 100;
+    void *ptrs[num_allocs];
+    int success_count = 0;
+    
+    // Allouer beaucoup de blocs de tailles variées
+    for (int i = 0; i < num_allocs; i++) {
+        size_t size = (i % 3 == 0) ? 32 : (i % 3 == 1) ? 512 : 2048;
+        ptrs[i] = malloc(size);
+        if (ptrs[i]) {
+            success_count++;
+            // Écrire des données pour tester
+            memset(ptrs[i], (char)(i % 256), size > 1 ? size - 1 : 0);
+        }
+    }
+    
+    test_result(success_count == num_allocs, "Multiple allocations all succeed");
+    printf("Allocated %d/%d blocks successfully\n", success_count, num_allocs);
+    
+    show_alloc_mem();
+    
+    // Vérifier l'intégrité des données
+    int integrity_ok = 1;
+    for (int i = 0; i < num_allocs; i++) {
+        if (ptrs[i]) {
+            size_t size = (i % 3 == 0) ? 32 : (i % 3 == 1) ? 512 : 2048;
+            if (size > 1 && ((char*)ptrs[i])[0] != (char)(i % 256)) {
+                integrity_ok = 0;
+                break;
+            }
+        }
+    }
+    test_result(integrity_ok, "Data integrity maintained across multiple allocations");
+    
+    // Libérer tous les blocs
+    for (int i = 0; i < num_allocs; i++) {
+        if (ptrs[i]) {
+            free(ptrs[i]);
+        }
+    }
+}
+
+void test_stress_realloc() {
+    TEST_SECTION("STRESS REALLOC TEST");
+    
+    char *ptr = malloc(16);
+    test_result(ptr != NULL, "Initial allocation for stress test");
+    
+    if (ptr) {
+        strcpy(ptr, "Start");
+        
+        // Série de realloc avec des tailles croissantes et décroissantes
+        size_t sizes[] = {32, 64, 128, 256, 512, 1024, 2048, 4096, 2048, 1024, 512, 256, 128, 64, 32, 16};
+        int num_sizes = sizeof(sizes) / sizeof(sizes[0]);
+        int all_success = 1;
+        
+        for (int i = 0; i < num_sizes; i++) {
+            ptr = realloc(ptr, sizes[i]);
+            if (!ptr) {
+                all_success = 0;
+                break;
+            }
+            // Vérifier que les données initiales sont toujours là
+            if (strncmp(ptr, "Start", 5) != 0) {
+                all_success = 0;
+                break;
+            }
+        }
+        
+        test_result(all_success, "Stress realloc sequence succeeds");
+        
+        if (ptr) free(ptr);
+    }
+}
+
+void test_boundary_values() {
+    TEST_SECTION("BOUNDARY VALUES TEST");
+    
+    // Tester les limites exactes entre catégories
+    void *tiny_max = malloc(128);      // Max TINY
+    void *small_min = malloc(129);     // Min SMALL
+    void *small_max = malloc(1024);    // Max SMALL
+    void *large_min = malloc(1025);    // Min LARGE
+    
+    test_result(tiny_max != NULL, "malloc(128) - TINY max boundary");
+    test_result(small_min != NULL, "malloc(129) - SMALL min boundary");
+    test_result(small_max != NULL, "malloc(1024) - SMALL max boundary");
+    test_result(large_min != NULL, "malloc(1025) - LARGE min boundary");
+    
+    // Vérifier les alignements aux limites
+    test_result(((uintptr_t)tiny_max % 8) == 0, "TINY max boundary aligned");
+    test_result(((uintptr_t)small_min % 8) == 0, "SMALL min boundary aligned");
+    test_result(((uintptr_t)small_max % 8) == 0, "SMALL max boundary aligned");
+    test_result(((uintptr_t)large_min % 8) == 0, "LARGE min boundary aligned");
+    
+    show_alloc_mem();
+    
+    free(tiny_max); free(small_min); 
+    free(small_max); free(large_min);
+}
+
+void test_free_edge_cases() {
+    TEST_SECTION("FREE EDGE CASES");
+    
+    // free(NULL) doit être sans effet
+    free(NULL);
+    test_result(1, "free(NULL) doesn't crash");
+    
+    // Double free - devrait être détecté si implémenté
+    void *ptr = malloc(100);
+    if (ptr) {
+        strcpy((char*)ptr, "Double free test");
+        free(ptr);
+        printf("Note: Uncomment next line to test double-free detection\n");
+        // free(ptr); // Décommenter pour tester la détection de double free
+    }
+}
+
+void test_memory_patterns() {
+    TEST_SECTION("MEMORY PATTERNS TEST");
+    
+    // Test avec différents patterns pour détecter la corruption
+    void *ptrs[5];
+    char patterns[] = {0x00, 0xFF, 0xAA, 0x55, 0xCC};
+    
+    for (int i = 0; i < 5; i++) {
+        ptrs[i] = malloc(256);
+        if (ptrs[i]) {
+            memset(ptrs[i], patterns[i], 256);
+        }
+    }
+    
+    // Vérifier l'intégrité des patterns
+    int pattern_integrity = 1;
+    for (int i = 0; i < 5; i++) {
+        if (ptrs[i]) {
+            char *ptr = (char*)ptrs[i];
+            for (int j = 0; j < 256; j++) {
+                if (ptr[j] != patterns[i]) {
+                    pattern_integrity = 0;
+                    break;
+                }
+            }
+        }
+    }
+    
+    test_result(pattern_integrity, "Memory pattern integrity maintained");
+    
+    // Nettoyer
+    for (int i = 0; i < 5; i++) {
+        if (ptrs[i]) free(ptrs[i]);
+    }
+}
+
+int main(void) {
+    printf(YELLOW "Starting comprehensive malloc/realloc/free test suite...\n" RESET);
+    
+    test_basic_malloc();
+    test_small_malloc();
+    test_large_malloc();
+    test_fragmentation();
+    test_realloc_tiny_to_tiny();
+    test_realloc_small_to_small();
+    test_realloc_large_to_large();
+    test_realloc_category_changes();
+    test_realloc_edge_cases();
+    test_multiple_allocations();
+    test_stress_realloc();
+    test_boundary_values();
+    test_free_edge_cases();
+    test_memory_patterns();
+    
+    printf(BLUE "\n=== FINAL MEMORY STATE ===" RESET "\n");
+    show_alloc_mem();
+    
+    printf(YELLOW "\n=== TEST SUMMARY ===" RESET "\n");
+    printf("Tests passed: " GREEN "%d" RESET "\n", tests_passed);
+    printf("Tests failed: " RED "%d" RESET "\n", tests_failed);
+    printf("Total tests: %d\n", tests_passed + tests_failed);
+    
+    if (tests_failed == 0) {
+        printf(GREEN "🎉 ALL TESTS PASSED! 🎉" RESET "\n");
+        return 0;
+    } else {
+        printf(RED "⚠️  Some tests failed. Check implementation." RESET "\n");
+        return 1;
+    }
 }

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -95,6 +95,34 @@ int main(void)
     printf("edge allocated (1025 bytes): OK\n");
     free(edge);
 
+	printf("\n=== TEST ALIGNMENT (8 bytes) ===\n");
+
+    void *a1 = malloc(1);
+    void *a2 = malloc(3);
+    void *a3 = malloc(50);
+    void *a4 = malloc(70);
+
+    printf("malloc(1)  -> %p (should be 8 aligned)\n", a1);
+    printf("malloc(3)  -> %p (should be 8 aligned)\n", a2);
+    printf("malloc(50) -> %p (should be 8 aligned)\n", a3);
+    printf("malloc(70) -> %p (should be 8 aligned)\n", a4);
+
+    if (((uintptr_t)a1 % 8) == 0 &&
+        ((uintptr_t)a2 % 8) == 0 &&
+        ((uintptr_t)a3 % 8) == 0 &&
+        ((uintptr_t)a4 % 8) == 0) {
+        printf("✅ All allocations are 8-byte aligned!\n");
+    } else {
+        printf("❌ Alignment error detected!\n");
+    }
+
+	show_alloc_mem();
+
+    free(a1);
+    free(a2);
+    free(a3);
+    free(a4);
+
     printf("\n=== TEST FREE INVALID ===\n");
     // Attention : ceci doit provoquer ton abort() custom
     // free(smaller); // décommenter pour tester le "double free detected"

--- a/srcs/malloc.c
+++ b/srcs/malloc.c
@@ -133,15 +133,12 @@ void	*large_malloc(size_t size)
 
 void	*malloc(size_t size)
 {
-	size_t	aligned_size;
-
 	ft_printf("je suis dans mon mallloc\n");
-	aligned_size = ALIGN(size);
-	if (aligned_size == 0)
+	if (size == 0)
 		return (NULL);
-	if (aligned_size <= n)
-		return (optimized_malloc(&g_malloc.tiny, n, aligned_size));
-	else if (aligned_size <= m)
-		return (optimized_malloc(&g_malloc.small, m, aligned_size));
-	return (large_malloc(aligned_size));
+	if (size <= n)
+		return (optimized_malloc(&g_malloc.tiny, n, size));
+	else if (size <= m)
+		return (optimized_malloc(&g_malloc.small, m, size));
+	return (large_malloc(size));
 }

--- a/srcs/realloc.c
+++ b/srcs/realloc.c
@@ -43,9 +43,9 @@ int	increase_memory(t_page *pages, t_block *block, size_t size)
 		+ GET_BLOCK_SIZE(next_block);
 	if (total < size)
 		return (0);
-	new_size = total - size - BLOCK_HEADER_SIZE;
-	SET_BLOCK_SIZE(block, size);
-	new_free_block = (void *)block + BLOCK_HEADER_SIZE + size;
+	new_size = total - ALIGN(size) - BLOCK_HEADER_SIZE;
+	SET_BLOCK_SIZE(block, ALIGN(size));
+	new_free_block = (void *)block + BLOCK_HEADER_SIZE + ALIGN(size);
 	memmove(new_free_block, next_block, BLOCK_HEADER_SIZE);
 	SET_BLOCK_SIZE(new_free_block, new_size);
 	current_page = find_page_by_block(pages, block);
@@ -89,25 +89,23 @@ void	*realloc_large_block(void *ptr, size_t size, t_block *block)
 void	*realloc(void *ptr, size_t size)
 {
 	t_block	*block;
-	size_t	aligned_size;
 
-	aligned_size = ALIGN(size);
 	if (ptr == NULL)
-		return (malloc(aligned_size));
-	else if (aligned_size == 0)
+		return (malloc(size));
+	else if (size == 0)
 	{
 		free(ptr);
 		return (NULL);
 	}
 	block = find_block(g_malloc.tiny, ptr);
 	if (block)
-		return (realloc_tiny_block(ptr, aligned_size, block));
+		return (realloc_tiny_block(ptr, size, block));
 	block = find_block(g_malloc.small, ptr);
 	if (block)
-		return (realloc_small_block(ptr, aligned_size, block));
+		return (realloc_small_block(ptr, size, block));
 	block = find_block(g_malloc.large, ptr);
 	if (block)
-		return (realloc_large_block(ptr, aligned_size, block));
+		return (realloc_large_block(ptr, size, block));
 	ft_putendl_fd("realloc(): invalid pointer", STDERR_FILENO);
 	abort();
 	return (NULL);

--- a/srcs/realloc.c
+++ b/srcs/realloc.c
@@ -25,7 +25,6 @@ void	*shrink_memory(t_page *pages, size_t size, t_block *block)
 	return (GET_BLOCK_PTR(block));
 }
 
-// TODO parfois pas besoin de toucher au block suivant
 int	increase_memory(t_page *pages, t_block *block, size_t size)
 {
 	size_t	new_size;
@@ -44,7 +43,7 @@ int	increase_memory(t_page *pages, t_block *block, size_t size)
 	if (total < size)
 		return (0);
 	new_size = total - ALIGN(size) - BLOCK_HEADER_SIZE;
-	SET_BLOCK_SIZE(block, ALIGN(size));
+	SET_BLOCK_SIZE(block, size);
 	new_free_block = (void *)block + BLOCK_HEADER_SIZE + ALIGN(size);
 	memmove(new_free_block, next_block, BLOCK_HEADER_SIZE);
 	SET_BLOCK_SIZE(new_free_block, new_size);
@@ -58,7 +57,7 @@ void	*realloc_block(void *ptr, size_t new_size, t_block *block,
 {
 	size_t	old_size;
 
-	old_size = GET_BLOCK_SIZE(block);
+	old_size = block->size;
 	if (new_size == old_size)
 		return (ptr);
 	if (new_size < old_size)

--- a/srcs/show_alloc_mem.c
+++ b/srcs/show_alloc_mem.c
@@ -7,7 +7,7 @@ size_t	print_block_info(t_block *block)
 	size_t	size;
 
 	start = GET_BLOCK_PTR(block);
-	size = GET_BLOCK_SIZE(block);
+	size = block->size;
 	print_mem((unsigned long long int)start);
 	ft_putstr(" - ");
 	print_mem((unsigned long long int)start + size);
@@ -60,12 +60,12 @@ void	show_alloc_mem(void)
 	size_t	total_size;
 
 	total_size = 0;
-	ft_putendl("----------------- Memory Allocation Report -----------------");
+	ft_putendl("\n----------------- Memory Allocation Report -----------------");
 	total_size += print_memory_zone(g_malloc.tiny, "TINY");
 	total_size += print_memory_zone(g_malloc.small, "SMALL");
 	total_size += print_memory_zone(g_malloc.large, "LARGE");
 	ft_putstr("Total : ");
 	ft_putnbr(total_size);
 	ft_putendl(" bytes");
-	ft_putendl("------------------------------------------------------------");
+	ft_putendl("------------------------------------------------------------\n");
 }

--- a/srcs/utils.c
+++ b/srcs/utils.c
@@ -1,11 +1,13 @@
 #include "../includes/malloc_internal.h"
+#include <string.h>
+#include <strings.h>
 
 void	initialize_blocks(t_block **block, size_t size)
 {
 	t_block	*current_block;
 
 	current_block = *block;
-	current_block->metadata = 0;
+	bzero(current_block->metadata, sizeof(current_block->metadata));
 	SET_BLOCK_SIZE(current_block, size);
 	SET_BLOCK_FREE(current_block);
 	SET_BLOCK_LAST(current_block);

--- a/srcs/utils.c
+++ b/srcs/utils.c
@@ -1,4 +1,5 @@
 #include "../includes/malloc_internal.h"
+#include <stddef.h>
 #include <string.h>
 #include <strings.h>
 
@@ -69,12 +70,14 @@ int	split_block(t_block *block, size_t size)
 {
 	t_block	*new_block;
 	long	new_size;
+	size_t aligned_size;
 
 	if (GET_BLOCK_SIZE(block) == size)
 		return (0);
-	new_size = GET_BLOCK_SIZE(block) - size - BLOCK_HEADER_SIZE;
+	aligned_size = ALIGN(size);
+	new_size = GET_BLOCK_SIZE(block) - aligned_size - BLOCK_HEADER_SIZE;
 	SET_BLOCK_SIZE(block, size);
-	new_block = (void *)block + sizeof(t_block) + size;
+	new_block = (void *)block + sizeof(t_block) + aligned_size;
 	initialize_blocks(&new_block, new_size);
 	if (IS_BLOCK_LAST(block))
 		SET_BLOCK_LAST(new_block);

--- a/srcs/utils.c
+++ b/srcs/utils.c
@@ -74,6 +74,10 @@ int	split_block(t_block *block, size_t size)
 
 	if (GET_BLOCK_SIZE(block) == size)
 		return (0);
+	if (size > ALIGN(block->size) - MEMORY_ALIGNMENT) {
+		SET_BLOCK_SIZE(block, size);
+		return (1);
+	}
 	aligned_size = ALIGN(size);
 	new_size = GET_BLOCK_SIZE(block) - aligned_size - BLOCK_HEADER_SIZE;
 	SET_BLOCK_SIZE(block, size);


### PR DESCRIPTION
Refactored the t_block structure to store the actual block size in a dedicated size field, while keeping metadata in a separate 4-byte space for flags and alignment. This makes block management clearer and prevents misinterpretation of encoded values.

Additionally, added an extensive test main program that exercises malloc, realloc, and free, including edge cases (unaligned sizes, large allocations, shrinking, expanding, and invalid frees).