### PR TITLE
feature: add some environement variables for malloc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CFLAGS = -Wall -Wextra -g3
 
 SRCS_DIR = srcs/
 
-SRCS = $(addprefix srcs/, main.c malloc.c free.c utils.c realloc.c calloc.c show_alloc_mem.c)
+SRCS = $(addprefix srcs/, main.c malloc.c free.c utils.c realloc.c calloc.c show_alloc_mem.c env_var.c)
 
 OBJS_DIR = .objs/
 

--- a/includes/malloc_internal.h
+++ b/includes/malloc_internal.h
@@ -63,6 +63,11 @@ typedef struct s_malloc
 	t_page			*tiny;  // page liee au tiny malloc
 	t_page			*small; // page liee au small malloc
 	t_page			*large; // page liee au large malloc
+	int				fail_size;
+	bool			set;
+	bool			verbose;
+	bool			no_defrag;
+	int				trace_file_fd;
 }					t_malloc;
 
 extern t_malloc	g_malloc;
@@ -74,4 +79,5 @@ int					split_block(t_block *block, size_t size);
 t_page				*find_page_by_block(t_page *pages, t_block *block);
 t_block				*find_block(t_page *pages, void *ptr);
 int					merge_block(t_block *block, t_block *prev_block);
+void				malloc_init(void);
 #endif

--- a/srcs/env_var.c
+++ b/srcs/env_var.c
@@ -1,0 +1,30 @@
+#include "../includes/malloc_internal.h"
+
+void	close_trace_file_fd(void)
+{
+	close(g_malloc.trace_file_fd);
+}
+
+void	malloc_init(void)
+{
+	char	*env;
+
+	g_malloc.set = true;
+	env = getenv("MALLOC_VERBOSE");
+	if (env && env[0] == '1')
+		g_malloc.verbose = true;
+	env = getenv("MALLOC_FAIL_SIZE");
+	if (env)
+		g_malloc.fail_size = atoi(env);
+	env = getenv("MALLOC_NO_DEFRAG");
+	if (env && env[0] == '1')
+		g_malloc.no_defrag = true;
+	env = getenv("MALLOC_TRACE_FILE");
+	if (env)
+	{
+		g_malloc.trace_file_fd = open(env, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+		if (g_malloc.trace_file_fd == -1)
+			ft_putendl_fd("Fail to pen trace file", STDERR_FILENO);
+		atexit(close_trace_file_fd);
+	}
+}

--- a/srcs/show_alloc_mem.c
+++ b/srcs/show_alloc_mem.c
@@ -1,5 +1,4 @@
 #include "../includes/malloc_internal.h"
-#include <stddef.h>
 
 size_t	print_block_info(t_block *block)
 {

--- a/srcs/utils.c
+++ b/srcs/utils.c
@@ -1,7 +1,4 @@
 #include "../includes/malloc_internal.h"
-#include <stddef.h>
-#include <string.h>
-#include <strings.h>
 
 void	initialize_blocks(t_block **block, size_t size)
 {
@@ -30,6 +27,8 @@ int	merge_block(t_block *block, t_block *prev_block)
 	int		nb_merge;
 	t_block	*next_block;
 
+	if (g_malloc.no_defrag == true)
+		return 0;
 	nb_merge = 0;
 	next_block = NEXT_BLOCK(block);
 	if (next_block && IS_BLOCK_FREE(next_block) == true)


### PR DESCRIPTION
Added support for environment variables in the custom malloc library to control debugging, tracing, and memory behavior dynamically:

MALLOC_VERBOSE – If set to 1, enables verbose debug output. Each call to malloc, realloc, or free prints detailed information including the pointer address and allocation size.

MALLOC_FAIL_SIZE – If set, any allocation request equal to this size will intentionally fail, which is useful for testing error handling in programs using malloc.

MALLOC_NO_DEFRAG – If set to 1, disables automatic memory defragmentation, allowing testing of allocation behavior without block merging.

MALLOC_TRACE_FILE – If set, specifies a file path where all allocation and deallocation events are logged. This file is opened at initialization and closed automatically at program exit.

These environment variables allow developers to trace memory usage, simulate failures, and debug allocation behavior without modifying source code, which is particularly useful in multi-threaded applications.