### PR TITLE
change the maner to manage free list

### DIFF
--- a/includes/lib_malloc.h
+++ b/includes/lib_malloc.h
@@ -5,15 +5,15 @@
 # include <sys/mman.h>
 # include <unistd.h>
 
-void	*malloc(size_t size);
+void	*my_malloc(size_t size);
 
-void	free(void *ptr);
+void	my_free(void *ptr);
 
-void	*realloc(void *ptr, size_t size);
+void	*my_realloc(void *ptr, size_t size);
 
-void	*reallocarray(void *ptr, size_t nmemb, size_t size);
+void	*my_reallocarray(void *ptr, size_t nmemb, size_t size);
 
-void	*calloc(size_t nmemb, size_t size);
+void	*my_calloc(size_t nmemb, size_t size);
 
 void	show_alloc_mem(void);
 

--- a/includes/malloc_internal.h
+++ b/includes/malloc_internal.h
@@ -10,23 +10,23 @@
 # include <pthread.h>
 #include <stdatomic.h>
 
-# define n 64   // taille en bytes pour etre considerer comme tiny malloc
-# define m 1024 // taille en bytes pour etre considerer comme small malloc
+# define n 64   // taille en bytes pour etre considerer comme tiny my_malloc
+# define m 1024 // taille en bytes pour etre considerer comme small my_malloc
 # define NB_BLOCK 100
 # define MEMORY_ALIGNMENT sizeof(size_t) // alignement de la memoire de 8bytes
 # define BLOCK_HEADER_SIZE sizeof(t_block)
 // arrondir un nombre au multiple de 8 superieur pour l'alignement
 # define ALIGN(x) (((x) + (MEMORY_ALIGNMENT - 1)) & ~(MEMORY_ALIGNMENT - 1))
 
-# define BLOCK_FLAG_FREE (1 << 0) // flag pour le free
+# define BLOCK_FLAG_FREE (1 << 0) // flag pour le my_free
 # define BLOCK_FLAG_LAST (1 << 1) // flag pour le dernier block
 
 # define SET_BLOCK_FREE(block) ((block)->flags |= BLOCK_FLAG_FREE)
-// mettre le block comme free
+// mettre le block comme my_free
 # define SET_BLOCK_USE(block) ((block)->flags &= ~BLOCK_FLAG_FREE)
 // mettre le block comme utilise
 # define IS_BLOCK_FREE(block) (((block)->flags & BLOCK_FLAG_FREE) != 0)
-// savoir si le block est free
+// savoir si le block est my_free
 
 # define SET_BLOCK_LAST(block) ((block)->flags |= BLOCK_FLAG_LAST)
 // mettre le block comme le dernier block
@@ -46,16 +46,12 @@
 
 # define GET_BLOCK_PTR(block) ((void *)(block) + BLOCK_HEADER_SIZE)
 
-#define SET_BLOCK_NEXT_FREE_PTR(block, next) \
-    (*(void **)GET_BLOCK_PTR(block) = (next))
-
-#define GET_BLOCK_NEXT_FREE_PTR(block) \
-    (*(void **)GET_BLOCK_PTR(block))
-
 typedef struct s_block
 {
-	unsigned int size; // changer ca en size_t
+	size_t size; // changer ca en size_t
 	uint8_t		flags;
+	struct s_block *next_free;
+	struct s_block *prev_free;
 }				t_block;
 
 typedef struct s_free_list {
@@ -85,9 +81,9 @@ typedef struct s_mutex_zone {
 
 typedef struct s_malloc
 {
-	t_mutex_zone	tiny; // page liee au tiny malloc
-	t_mutex_zone	small; // page liee au small malloc
-	t_mutex_zone	large; // page liee au large malloc
+	t_mutex_zone	tiny; // page liee au tiny my_malloc
+	t_mutex_zone	small; // page liee au small my_malloc
+	t_mutex_zone	large; // page liee au large my_malloc
 	int				fail_size;
 	atomic_bool			set;
 	bool			verbose;
@@ -112,8 +108,5 @@ bool				is_gonna_overflow(size_t nmemb, size_t size);
 char				*strdup_internal(const char *s);
 void				add_block_to_free_list(t_page *page, t_block *block);
 void				remove_block_free_list(t_page *page, t_block *block);
-
-// t_page *next_page(t_page *current_page);
-
 
 #endif

--- a/srcs/calloc.c
+++ b/srcs/calloc.c
@@ -22,7 +22,7 @@ void	*calloc_internal(size_t nmemb, size_t size)
 	return (ptr);
 }
 
-void *calloc(size_t nmemb, size_t size) {
+void *my_calloc(size_t nmemb, size_t size) {
     void *ptr;
 
 	pthread_mutex_lock(&g_malloc_lock);
@@ -32,12 +32,12 @@ void *calloc(size_t nmemb, size_t size) {
     if (is_gonna_overflow(nmemb, size)) {
         if (g_malloc.verbose) {
             ft_printf_fd(STDERR_FILENO,
-                "[ERROR] calloc overflow detected\n"
+                "[ERROR] my_calloc overflow detected\n"
                 "\t-> nmemb: %u, size: %u (multiplication too large)\n", nmemb, size);
         }
         if (g_malloc.trace_file_fd != -1) {
             ft_printf_fd(g_malloc.trace_file_fd,
-                "[ERROR] calloc overflow (nmemb: %u, size: %u)\n", nmemb, size);
+                "[ERROR] my_calloc overflow (nmemb: %u, size: %u)\n", nmemb, size);
         }
         return NULL;
     }
@@ -46,7 +46,7 @@ void *calloc(size_t nmemb, size_t size) {
 
     if (g_malloc.verbose) {
         ft_printf_fd(STDERR_FILENO,
-            "[DEBUG] calloc(nmemb: %u, size: %u) -> %p (%zu bytes)\n",
+            "[DEBUG] my_calloc(nmemb: %u, size: %u) -> %p (%zu bytes)\n",
             nmemb, size, ptr, nmemb * size);
 
         ft_printf_fd(STDERR_FILENO, "Stack trace (most recent first):\n");
@@ -54,7 +54,7 @@ void *calloc(size_t nmemb, size_t size) {
 
     if (g_malloc.trace_file_fd != -1) {
         ft_printf_fd(g_malloc.trace_file_fd,
-            "calloc(nmemb: %u, size: %u) -> %p\n",
+            "my_calloc(nmemb: %u, size: %u) -> %p\n",
             nmemb, size, ptr);
     }
 

--- a/srcs/env_var.c
+++ b/srcs/env_var.c
@@ -1,6 +1,4 @@
 #include "../includes/malloc_internal.h"
-#include <bits/pthreadtypes.h>
-#include <pthread.h>
 
 pthread_mutex_t g_malloc_lock = PTHREAD_MUTEX_INITIALIZER;
 

--- a/srcs/free.c
+++ b/srcs/free.c
@@ -1,12 +1,10 @@
 #include "../includes/malloc_internal.h"
-#include <pthread.h>
-#include <unistd.h>
 
 void	block_free(t_block *block)
 {
 	if (IS_BLOCK_FREE(block) == true)
 	{
-		ft_putendl_fd("free(): double free detected in tcache 2",
+		ft_putendl_fd("my_free(): double my_free detected in tcache 2",
 						STDERR_FILENO);
 		abort();
 	}
@@ -101,11 +99,11 @@ void	free_internal(void *ptr)
 	if (free_large_block(ptr))
 		return (void)pthread_mutex_unlock(&g_malloc.large.mutex);
 	pthread_mutex_unlock(&g_malloc.large.mutex);
-	ft_putendl_fd("free(): invalid pointer", STDERR_FILENO);
+	ft_putendl_fd("my_free(): invalid pointer", STDERR_FILENO);
 	abort();
 }
 
-void	free(void *ptr)
+void	my_free(void *ptr)
 {
 	pthread_mutex_lock(&g_malloc_lock);
 	if (!g_malloc.set)
@@ -115,18 +113,18 @@ void	free(void *ptr)
 	{
 		if (ptr == NULL)
 			ft_printf_fd(STDERR_FILENO,
-							"[DEBUG] free(NULL)\n");
+							"[DEBUG] my_free(NULL)\n");
 		else
 			ft_printf_fd(STDERR_FILENO,
-							"[DEBUG] free(%p)\n",
+							"[DEBUG] my_free(%p)\n",
 							ptr);
 	}
 	if (g_malloc.trace_file_fd != -1)
 	{
 		if (ptr == NULL)
-			ft_printf_fd(g_malloc.trace_file_fd, "free(NULL)\n");
+			ft_printf_fd(g_malloc.trace_file_fd, "my_free(NULL)\n");
 		else
-			ft_printf_fd(g_malloc.trace_file_fd, "free(%p)\n",
+			ft_printf_fd(g_malloc.trace_file_fd, "my_free(%p)\n",
 					ptr);
 	}
 	free_internal(ptr);

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -29,119 +29,119 @@
 // }
 
 // void test_basic_malloc() {
-//     TEST_SECTION("BASIC malloc TESTS");
+//     TEST_SECTION("BASIC my_malloc TESTS");
     
-//     // Test 1: malloc(0) - comportement défini par l'implémentation
-//     void *p0 = malloc(0);
-//     test_result(p0 != NULL || p0 == NULL, "malloc(0) returns valid result");
-//     if (p0) free(p0);
+//     // Test 1: my_malloc(0) - comportement défini par l'implémentation
+//     void *p0 = my_malloc(0);
+//     test_result(p0 != NULL || p0 == NULL, "my_malloc(0) returns valid result");
+//     if (p0) my_free(p0);
     
 //     // Test 2: petites tailles (TINY)
-//     char *tiny1 = malloc(1);
-//     char *tiny8 = malloc(8);
-//     char *tiny16 = malloc(16);
-//     char *tiny32 = malloc(32);
-//     char *tiny64 = malloc(64);
-//     char *tiny128 = malloc(128);
+//     char *tiny1 = my_malloc(1);
+//     char *tiny8 = my_malloc(8);
+//     char *tiny16 = my_malloc(16);
+//     char *tiny32 = my_malloc(32);
+//     char *tiny64 = my_malloc(64);
+//     char *tiny128 = my_malloc(128);
     
-//     test_result(tiny1 != NULL, "malloc(1) succeeds");
-//     test_result(tiny8 != NULL, "malloc(8) succeeds");
-//     test_result(tiny16 != NULL, "malloc(16) succeeds");
-//     test_result(tiny32 != NULL, "malloc(32) succeeds");
-//     test_result(tiny64 != NULL, "malloc(64) succeeds");
-//     test_result(tiny128 != NULL, "malloc(128) succeeds");
+//     test_result(tiny1 != NULL, "my_malloc(1) succeeds");
+//     test_result(tiny8 != NULL, "my_malloc(8) succeeds");
+//     test_result(tiny16 != NULL, "my_malloc(16) succeeds");
+//     test_result(tiny32 != NULL, "my_malloc(32) succeeds");
+//     test_result(tiny64 != NULL, "my_malloc(64) succeeds");
+//     test_result(tiny128 != NULL, "my_malloc(128) succeeds");
     
 //     // Test d'alignement (8 bytes)
-//     test_result(((uintptr_t)tiny1 % 8) == 0, "malloc(1) is 8-byte aligned");
-//     test_result(((uintptr_t)tiny8 % 8) == 0, "malloc(8) is 8-byte aligned");
-//     test_result(((uintptr_t)tiny16 % 8) == 0, "malloc(16) is 8-byte aligned");
-//     test_result(((uintptr_t)tiny32 % 8) == 0, "malloc(32) is 8-byte aligned");
-//     test_result(((uintptr_t)tiny64 % 8) == 0, "malloc(64) is 8-byte aligned");
-//     test_result(((uintptr_t)tiny128 % 8) == 0, "malloc(128) is 8-byte aligned");
+//     test_result(((uintptr_t)tiny1 % 8) == 0, "my_malloc(1) is 8-byte aligned");
+//     test_result(((uintptr_t)tiny8 % 8) == 0, "my_malloc(8) is 8-byte aligned");
+//     test_result(((uintptr_t)tiny16 % 8) == 0, "my_malloc(16) is 8-byte aligned");
+//     test_result(((uintptr_t)tiny32 % 8) == 0, "my_malloc(32) is 8-byte aligned");
+//     test_result(((uintptr_t)tiny64 % 8) == 0, "my_malloc(64) is 8-byte aligned");
+//     test_result(((uintptr_t)tiny128 % 8) == 0, "my_malloc(128) is 8-byte aligned");
     
 //     // Test d'écriture/lecture
 //     if (tiny32) {
 //         strcpy(tiny32, "Hello");
-//         test_result(strcmp(tiny32, "Hello") == 0, "Write/read in tiny malloc");
+//         test_result(strcmp(tiny32, "Hello") == 0, "Write/read in tiny my_malloc");
 //     }
     
 //     show_alloc_mem_ex();
     
-//     free(tiny1); free(tiny8); free(tiny16); 
-//     free(tiny32); free(tiny64); free(tiny128);
+//     my_free(tiny1); my_free(tiny8); my_free(tiny16); 
+//     my_free(tiny32); my_free(tiny64); my_free(tiny128);
 // }
 
 // void test_small_malloc() {
-//     TEST_SECTION("SMALL malloc TESTS");
+//     TEST_SECTION("SMALL my_malloc TESTS");
     
 //     // Test tailles SMALL (129 à 1024 bytes)
-//     char *small200 = malloc(200);
-//     char *small400 = malloc(400);
-//     char *small600 = malloc(600);
-//     char *small800 = malloc(800);
-//     char *small1000 = malloc(1000);
-//     char *small1024 = malloc(1024); // limite SMALL
+//     char *small200 = my_malloc(200);
+//     char *small400 = my_malloc(400);
+//     char *small600 = my_malloc(600);
+//     char *small800 = my_malloc(800);
+//     char *small1000 = my_malloc(1000);
+//     char *small1024 = my_malloc(1024); // limite SMALL
     
-//     test_result(small200 != NULL, "malloc(200) succeeds");
-//     test_result(small400 != NULL, "malloc(400) succeeds");
-//     test_result(small600 != NULL, "malloc(600) succeeds");
-//     test_result(small800 != NULL, "malloc(800) succeeds");
-//     test_result(small1000 != NULL, "malloc(1000) succeeds");
-//     test_result(small1024 != NULL, "malloc(1024) succeeds");
+//     test_result(small200 != NULL, "my_malloc(200) succeeds");
+//     test_result(small400 != NULL, "my_malloc(400) succeeds");
+//     test_result(small600 != NULL, "my_malloc(600) succeeds");
+//     test_result(small800 != NULL, "my_malloc(800) succeeds");
+//     test_result(small1000 != NULL, "my_malloc(1000) succeeds");
+//     test_result(small1024 != NULL, "my_malloc(1024) succeeds");
     
 //     // Test d'alignement
-//     test_result(((uintptr_t)small200 % 8) == 0, "malloc(200) is 8-byte aligned");
-//     test_result(((uintptr_t)small400 % 8) == 0, "malloc(400) is 8-byte aligned");
-//     test_result(((uintptr_t)small1024 % 8) == 0, "malloc(1024) is 8-byte aligned");
+//     test_result(((uintptr_t)small200 % 8) == 0, "my_malloc(200) is 8-byte aligned");
+//     test_result(((uintptr_t)small400 % 8) == 0, "my_malloc(400) is 8-byte aligned");
+//     test_result(((uintptr_t)small1024 % 8) == 0, "my_malloc(1024) is 8-byte aligned");
     
 //     // Test d'écriture dans les blocs
 //     if (small400) {
 //         memset(small400, 'A', 399);
 //         small400[399] = '\0';
-//         test_result(small400[0] == 'A' && small400[398] == 'A', "Write/read in small malloc");
+//         test_result(small400[0] == 'A' && small400[398] == 'A', "Write/read in small my_malloc");
 //     }
     
 //     show_alloc_mem_ex();
     
-//     free(small200); free(small400); free(small600);
-//     free(small800); free(small1000); free(small1024);
+//     my_free(small200); my_free(small400); my_free(small600);
+//     my_free(small800); my_free(small1000); my_free(small1024);
 // }
 
 // void test_large_malloc() {
-//     TEST_SECTION("LARGE malloc TESTS");
+//     TEST_SECTION("LARGE my_malloc TESTS");
     
 //     // Test tailles LARGE (> 1024 bytes)
-//     char *large1025 = malloc(1025); // première taille LARGE
-//     char *large2048 = malloc(2048);
-//     char *large4096 = malloc(4096);
-//     char *large8192 = malloc(8192);
-//     char *large16384 = malloc(16384);
-//     char *large_huge = malloc(1024 * 1024); // 1MB
+//     char *large1025 = my_malloc(1025); // première taille LARGE
+//     char *large2048 = my_malloc(2048);
+//     char *large4096 = my_malloc(4096);
+//     char *large8192 = my_malloc(8192);
+//     char *large16384 = my_malloc(16384);
+//     char *large_huge = my_malloc(1024 * 1024); // 1MB
     
-//     test_result(large1025 != NULL, "malloc(1025) succeeds");
-//     test_result(large2048 != NULL, "malloc(2048) succeeds");
-//     test_result(large4096 != NULL, "malloc(4096) succeeds");
-//     test_result(large8192 != NULL, "malloc(8192) succeeds");
-//     test_result(large16384 != NULL, "malloc(16384) succeeds");
-//     test_result(large_huge != NULL, "malloc(1MB) succeeds");
+//     test_result(large1025 != NULL, "my_malloc(1025) succeeds");
+//     test_result(large2048 != NULL, "my_malloc(2048) succeeds");
+//     test_result(large4096 != NULL, "my_malloc(4096) succeeds");
+//     test_result(large8192 != NULL, "my_malloc(8192) succeeds");
+//     test_result(large16384 != NULL, "my_malloc(16384) succeeds");
+//     test_result(large_huge != NULL, "my_malloc(1MB) succeeds");
     
 //     // Test d'alignement
-//     test_result(((uintptr_t)large1025 % 8) == 0, "malloc(1025) is 8-byte aligned");
-//     test_result(((uintptr_t)large2048 % 8) == 0, "malloc(2048) is 8-byte aligned");
-//     test_result(((uintptr_t)large_huge % 8) == 0, "malloc(1MB) is 8-byte aligned");
+//     test_result(((uintptr_t)large1025 % 8) == 0, "my_malloc(1025) is 8-byte aligned");
+//     test_result(((uintptr_t)large2048 % 8) == 0, "my_malloc(2048) is 8-byte aligned");
+//     test_result(((uintptr_t)large_huge % 8) == 0, "my_malloc(1MB) is 8-byte aligned");
     
 //     // Test d'écriture dans un gros bloc
 //     if (large_huge) {
 //         large_huge[0] = 'X';
 //         large_huge[1024 * 1024 - 1] = 'Y';
 //         test_result(large_huge[0] == 'X' && large_huge[1024 * 1024 - 1] == 'Y', 
-//                    "Write/read in 1MB malloc");
+//                    "Write/read in 1MB my_malloc");
 //     }
     
 //     show_alloc_mem_ex();
     
-//     free(large1025); free(large2048); free(large4096);
-//     free(large8192); free(large16384); free(large_huge);
+//     my_free(large1025); my_free(large2048); my_free(large4096);
+//     my_free(large8192); my_free(large16384); my_free(large_huge);
 // }
 
 // void test_fragmentation() {
@@ -152,15 +152,15 @@
     
 //     // Allouer 10 blocs
 //     for (int i = 0; i < 10; i++) {
-//         ptrs[i] = malloc(64);
-//         test_result(ptrs[i] != NULL, "Fragmentation malloc succeeds");
+//         ptrs[i] = my_malloc(64);
+//         test_result(ptrs[i] != NULL, "Fragmentation my_malloc succeeds");
 //     }
     
 //     show_alloc_mem_ex();
     
 //     // Libérer les blocs impairs (créer des trous)
 //     for (int i = 1; i < 10; i += 2) {
-//         free(ptrs[i]);
+//         my_free(ptrs[i]);
 //         ptrs[i] = NULL;
 //     }
     
@@ -168,146 +168,145 @@
 //     show_alloc_mem_ex();
     
 //     // Essayer de réallouer dans les trous
-//     void *new_ptr = malloc(32); // devrait réutiliser un trou
-//     test_result(new_ptr != NULL, "malloc after fragmentation succeeds");
+//     void *new_ptr = my_malloc(32); // devrait réutiliser un trou
+//     test_result(new_ptr != NULL, "my_malloc after fragmentation succeeds");
     
 //     // Nettoyer
 //     for (int i = 0; i < 10; i += 2) {
-//         free(ptrs[i]);
+//         my_free(ptrs[i]);
 //     }
-// 	printf("je suis la\n");
-//     free(new_ptr);
-// 	printf("je suis la1\n");
+//     my_free(new_ptr);
 // }
 
 // void test_realloc_tiny_to_tiny() {
-//     TEST_SECTION("realloc TINY->TINY TESTS");
+//     TEST_SECTION("my_realloc TINY->TINY TESTS");
     
-//     char *ptr = malloc(16);
-//     test_result(ptr != NULL, "Initial malloc(16) for realloc");
+//     char *ptr = my_malloc(16);
+//     test_result(ptr != NULL, "Initial my_malloc(16) for my_realloc");
     
 //     if (ptr) {
 //         strcpy(ptr, "Hello");
         
 //         // Agrandir dans TINY
-//         ptr = realloc(ptr, 32);
-//         test_result(ptr != NULL, "realloc(16->32) succeeds");
-//         test_result(strcmp(ptr, "Hello") == 0, "Data preserved in realloc(16->32)");
+//         ptr = my_realloc(ptr, 32);
+//         test_result(ptr != NULL, "my_realloc(16->32) succeeds");
+//         test_result(strcmp(ptr, "Hello") == 0, "Data preserved in my_realloc(16->32)");
         
 //         // Réduire dans TINY
-//         ptr = realloc(ptr, 8);
-//         test_result(ptr != NULL, "realloc(32->8) succeeds");
-//         test_result(strncmp(ptr, "Hello", 5) == 0, "Data preserved in realloc(32->8)");
+//         ptr = my_realloc(ptr, 8);
+//         test_result(ptr != NULL, "my_realloc(32->8) succeeds");
+//         test_result(strncmp(ptr, "Hello", 5) == 0, "Data preserved in my_realloc(32->8)");
         
-//         free(ptr);
+//         my_free(ptr);
+
 //     }
 // }
 
 // void test_realloc_small_to_small() {
-//     TEST_SECTION("realloc SMALL->SMALL TESTS");
+//     TEST_SECTION("my_realloc SMALL->SMALL TESTS");
     
-//     char *ptr = malloc(200);
-//     test_result(ptr != NULL, "Initial malloc(200) for realloc");
+//     char *ptr = my_malloc(200);
+//     test_result(ptr != NULL, "Initial my_malloc(200) for my_realloc");
     
 //     if (ptr) {
 //         memset(ptr, 'A', 199);
 //         ptr[199] = '\0';
         
 //         // Agrandir dans SMALL
-//         ptr = realloc(ptr, 500);
-//         test_result(ptr != NULL, "realloc(200->500) succeeds");
-//         test_result(ptr[0] == 'A' && ptr[198] == 'A', "Data preserved in realloc(200->500)");
+//         ptr = my_realloc(ptr, 500);
+//         test_result(ptr != NULL, "my_realloc(200->500) succeeds");
+//         test_result(ptr[0] == 'A' && ptr[198] == 'A', "Data preserved in my_realloc(200->500)");
         
 //         // Réduire dans SMALL
-//         ptr = realloc(ptr, 150);
-//         test_result(ptr != NULL, "realloc(500->150) succeeds");
-//         test_result(ptr[0] == 'A' && ptr[149] == 'A', "Data preserved in realloc(500->150)");
+//         ptr = my_realloc(ptr, 150);
+//         test_result(ptr != NULL, "my_realloc(500->150) succeeds");
+//         test_result(ptr[0] == 'A' && ptr[149] == 'A', "Data preserved in my_realloc(500->150)");
         
-//         free(ptr);
+//         my_free(ptr);
 //     }
 // }
 
 // void test_realloc_large_to_large() {
-//     TEST_SECTION("realloc LARGE->LARGE TESTS");
+//     TEST_SECTION("my_realloc LARGE->LARGE TESTS");
     
-//     char *ptr = malloc(2048);
-//     test_result(ptr != NULL, "Initial malloc(2048) for realloc");
+//     char *ptr = my_malloc(2048);
+//     test_result(ptr != NULL, "Initial my_malloc(2048) for my_realloc");
     
 //     if (ptr) {
 //         memset(ptr, 'B', 2047);
 //         ptr[2047] = '\0';
         
 //         // Agrandir dans LARGE
-//         ptr = realloc(ptr, 4096);
-//         test_result(ptr != NULL, "realloc(2048->4096) succeeds");
-//         test_result(ptr[0] == 'B' && ptr[2046] == 'B', "Data preserved in realloc(2048->4096)");
+//         ptr = my_realloc(ptr, 4096);
+//         test_result(ptr != NULL, "my_realloc(2048->4096) succeeds");
+//         test_result(ptr[0] == 'B' && ptr[2046] == 'B', "Data preserved in my_realloc(2048->4096)");
         
 //         // Réduire dans LARGE
-//         ptr = realloc(ptr, 1500);
-//         test_result(ptr != NULL, "realloc(4096->1500) succeeds");
-//         test_result(ptr[0] == 'B' && ptr[1499] == 'B', "Data preserved in realloc(4096->1500)");
+//         ptr = my_realloc(ptr, 1500);
+//         test_result(ptr != NULL, "my_realloc(4096->1500) succeeds");
+//         test_result(ptr[0] == 'B' && ptr[1499] == 'B', "Data preserved in my_realloc(4096->1500)");
         
-//         free(ptr);
+//         my_free(ptr);
 //     }
 // }
 
 // void test_realloc_category_changes() {
-//     TEST_SECTION("realloc CATEGORY CHANGE TESTS");
+//     TEST_SECTION("my_realloc CATEGORY CHANGE TESTS");
     
 //     // TINY -> SMALL
-//     char *ptr = malloc(64);
+//     char *ptr = my_malloc(64);
 //     if (ptr) {
 //         strcpy(ptr, "TinyToSmall");
-//         ptr = realloc(ptr, 256);
-//         test_result(ptr != NULL, "realloc TINY->SMALL succeeds");
+//         ptr = my_realloc(ptr, 256);
+//         test_result(ptr != NULL, "my_realloc TINY->SMALL succeeds");
 //         test_result(strcmp(ptr, "TinyToSmall") == 0, "Data preserved TINY->SMALL");
         
 //         // SMALL -> LARGE
 //         strcat(ptr, " and SmallToLarge");
-//         ptr = realloc(ptr, 2048);
-//         test_result(ptr != NULL, "realloc SMALL->LARGE succeeds");
+//         ptr = my_realloc(ptr, 2048);
+//         test_result(ptr != NULL, "my_realloc SMALL->LARGE succeeds");
 //         test_result(strstr(ptr, "TinyToSmall") != NULL, "Data preserved SMALL->LARGE");
         
 //         // LARGE -> SMALL
-//         ptr = realloc(ptr, 512);
-//         test_result(ptr != NULL, "realloc LARGE->SMALL succeeds");
+//         ptr = my_realloc(ptr, 512);
+//         test_result(ptr != NULL, "my_realloc LARGE->SMALL succeeds");
 //         test_result(strstr(ptr, "TinyToSmall") != NULL, "Data preserved LARGE->SMALL");
         
 //         // SMALL -> TINY
-//         ptr = realloc(ptr, 32);
-//         test_result(ptr != NULL, "realloc SMALL->TINY succeeds");
+//         ptr = my_realloc(ptr, 32);
+//         test_result(ptr != NULL, "my_realloc SMALL->TINY succeeds");
 //         test_result(strncmp(ptr, "TinyToSmall", 11) == 0, "Data preserved SMALL->TINY");
         
-//         free(ptr);
+//         my_free(ptr);
 //     }
 // }
 
 // void test_realloc_edge_cases() {
-//     TEST_SECTION("realloc EDGE CASES");
+//     TEST_SECTION("my_realloc EDGE CASES");
     
-//     // realloc(NULL, size) = malloc(size)
-//     char *ptr = realloc(NULL, 100);
-//     test_result(ptr != NULL, "realloc(NULL, 100) works like malloc");
+//     // my_realloc(NULL, size) = my_malloc(size)
+//     char *ptr = my_realloc(NULL, 100);
+//     test_result(ptr != NULL, "my_realloc(NULL, 100) works like my_malloc");
 //     if (ptr) {
-//         strcpy(ptr, "realloc NULL test");
-//         test_result(strcmp(ptr, "realloc NULL test") == 0, "Write after realloc(NULL)");
+//         strcpy(ptr, "my_realloc NULL test");
+//         test_result(strcmp(ptr, "my_realloc NULL test") == 0, "Write after my_realloc(NULL)");
 //     }
     
-//     // realloc(ptr, 0) = free(ptr) + return implementation-defined
-//     void *result = realloc(ptr, 0);
-//     test_result(1, "realloc(ptr, 0) completes without crash");
-//     if (result) free(result);
+//     // my_realloc(ptr, 0) = my_free(ptr) + return implementation-defined
+//     void *result = my_realloc(ptr, 0);
+//     test_result(1, "my_realloc(ptr, 0) completes without crash");
+//     if (result) my_free(result);
     
-//     // realloc même taille
-//     ptr = malloc(100);
+//     // my_realloc même taille
+//     ptr = my_malloc(100);
 //     if (ptr) {
 //         strcpy(ptr, "Same size test");
 //         char *old_ptr = ptr;
-//         ptr = realloc(ptr, 100);
-//         test_result(ptr != NULL, "realloc same size succeeds");
-//         test_result(strcmp(ptr, "Same size test") == 0, "Data preserved same size realloc");
-//         test_result(old_ptr == ptr, "Pointer preserved same size realloc");
-//         free(ptr);
+//         ptr = my_realloc(ptr, 100);
+//         test_result(ptr != NULL, "my_realloc same size succeeds");
+//         test_result(strcmp(ptr, "Same size test") == 0, "Data preserved same size my_realloc");
+//         test_result(old_ptr == ptr, "Pointer preserved same size my_realloc");
+//         my_free(ptr);
 //     }
 // }
 
@@ -321,7 +320,7 @@
 //     // Allouer beaucoup de blocs de tailles variées
 //     for (int i = 0; i < num_allocs; i++) {
 //         size_t size = (i % 3 == 0) ? 32 : (i % 3 == 1) ? 512 : 2048;
-//         ptrs[i] = malloc(size);
+//         ptrs[i] = my_malloc(size);
 //         if (ptrs[i]) {
 //             success_count++;
 //             // Écrire des données pour tester
@@ -350,31 +349,32 @@
 //     // Libérer tous les blocs
 //     for (int i = 0; i < num_allocs; i++) {
 //         if (ptrs[i]) {
-//             free(ptrs[i]);
+//             my_free(ptrs[i]);
 //         }
 //     }
 // }
 
 // void test_stress_realloc() {
-//     TEST_SECTION("STRESS realloc TEST");
+//     TEST_SECTION("STRESS my_realloc TEST");
     
-//     char *ptr = malloc(16);
+//     char *ptr = my_malloc(16);
 //     test_result(ptr != NULL, "Initial allocation for stress test");
     
 //     if (ptr) {
 //         strcpy(ptr, "Start");
         
-//         // Série de realloc avec des tailles croissantes et décroissantes
+//         // Série de my_realloc avec des tailles croissantes et décroissantes
 //         size_t sizes[] = {32, 64, 128, 256, 512, 1024, 2048, 4096, 2048, 1024, 512, 256, 128, 64, 32, 16};
 //         int num_sizes = sizeof(sizes) / sizeof(sizes[0]);
 //         int all_success = 1;
         
 //         for (int i = 0; i < num_sizes; i++) {
-//             ptr = realloc(ptr, sizes[i]);
+//             ptr = my_realloc(ptr, sizes[i]);
 //             if (!ptr) {
 //                 all_success = 0;
 //                 break;
 //             }
+// 			show_alloc_mem_ex();
 //             // Vérifier que les données initiales sont toujours là
 //             if (strncmp(ptr, "Start", 5) != 0) {
 //                 all_success = 0;
@@ -382,9 +382,9 @@
 //             }
 //         }
         
-//         test_result(all_success, "Stress realloc sequence succeeds");
+//         test_result(all_success, "Stress my_realloc sequence succeeds");
         
-//         if (ptr) free(ptr);
+//         if (ptr) my_free(ptr);
 //     }
 // }
 
@@ -392,15 +392,15 @@
 //     TEST_SECTION("BOUNDARY VALUES TEST");
     
 //     // Tester les limites exactes entre catégories
-//     void *tiny_max = malloc(128);      // Max TINY
-//     void *small_min = malloc(129);     // Min SMALL
-//     void *small_max = malloc(1024);    // Max SMALL
-//     void *large_min = malloc(1025);    // Min LARGE
+//     void *tiny_max = my_malloc(128);      // Max TINY
+//     void *small_min = my_malloc(129);     // Min SMALL
+//     void *small_max = my_malloc(1024);    // Max SMALL
+//     void *large_min = my_malloc(1025);    // Min LARGE
     
-//     test_result(tiny_max != NULL, "malloc(128) - TINY max boundary");
-//     test_result(small_min != NULL, "malloc(129) - SMALL min boundary");
-//     test_result(small_max != NULL, "malloc(1024) - SMALL max boundary");
-//     test_result(large_min != NULL, "malloc(1025) - LARGE min boundary");
+//     test_result(tiny_max != NULL, "my_malloc(128) - TINY max boundary");
+//     test_result(small_min != NULL, "my_malloc(129) - SMALL min boundary");
+//     test_result(small_max != NULL, "my_malloc(1024) - SMALL max boundary");
+//     test_result(large_min != NULL, "my_malloc(1025) - LARGE min boundary");
     
 //     // Vérifier les alignements aux limites
 //     test_result(((uintptr_t)tiny_max % 8) == 0, "TINY max boundary aligned");
@@ -410,24 +410,24 @@
     
 //     show_alloc_mem_ex();
     
-//     free(tiny_max); free(small_min); 
-//     free(small_max); free(large_min);
+//     my_free(tiny_max); my_free(small_min); 
+//     my_free(small_max); my_free(large_min);
 // }
 
 // void test_free_edge_cases() {
-//     TEST_SECTION("free EDGE CASES");
+//     TEST_SECTION("my_free EDGE CASES");
     
-//     // free(NULL) doit être sans effet
-//     free(NULL);
-//     test_result(1, "free(NULL) doesn't crash");
+//     // my_free(NULL) doit être sans effet
+//     my_free(NULL);
+//     test_result(1, "my_free(NULL) doesn't crash");
     
-//     // Double free - devrait être détecté si implémenté
-//     void *ptr = malloc(100);
+//     // Double my_free - devrait être détecté si implémenté
+//     void *ptr = my_malloc(100);
 //     if (ptr) {
-//         strcpy((char*)ptr, "Double free test");
-//         free(ptr);
-//         printf("Note: Uncomment next line to test double-free detection\n");
-//         // free(ptr); // Décommenter pour tester la détection de double free
+//         strcpy((char*)ptr, "Double my_free test");
+//         my_free(ptr);
+//         printf("Note: Uncomment next line to test double-my_free detection\n");
+//         // my_free(ptr); // Décommenter pour tester la détection de double my_free
 //     }
 // }
 
@@ -439,7 +439,7 @@
 //     char patterns[] = {0x00, 0xFF, 0xAA, 0x55, 0xCC};
     
 //     for (int i = 0; i < 5; i++) {
-//         ptrs[i] = malloc(256);
+//         ptrs[i] = my_malloc(256);
 //         if (ptrs[i]) {
 //             memset(ptrs[i], patterns[i], 256);
 //         }
@@ -463,27 +463,27 @@
     
 //     // Nettoyer
 //     for (int i = 0; i < 5; i++) {
-//         if (ptrs[i]) free(ptrs[i]);
+//         if (ptrs[i]) my_free(ptrs[i]);
 //     }
 // }
 
 // void test_calloc_basic() {
-//     TEST_SECTION("calloc BASIC TESTS");
+//     TEST_SECTION("my_calloc BASIC TESTS");
     
-//     // Test 1: calloc(0, size) et calloc(nmemb, 0)
-//     void *p1 = calloc(0, 10);
-//     void *p2 = calloc(10, 0);
-//     void *p3 = calloc(0, 0);
-//     test_result(p1 != NULL || p1 == NULL, "calloc(0, 10) returns valid result");
-//     test_result(p2 != NULL || p2 == NULL, "calloc(10, 0) returns valid result");
-//     test_result(p3 != NULL || p3 == NULL, "calloc(0, 0) returns valid result");
-//     if (p1) free(p1);
-//     if (p2) free(p2);
-//     if (p3) free(p3);
+//     // Test 1: my_calloc(0, size) et my_calloc(nmemb, 0)
+//     void *p1 = my_calloc(0, 10);
+//     void *p2 = my_calloc(10, 0);
+//     void *p3 = my_calloc(0, 0);
+//     test_result(p1 != NULL || p1 == NULL, "my_calloc(0, 10) returns valid result");
+//     test_result(p2 != NULL || p2 == NULL, "my_calloc(10, 0) returns valid result");
+//     test_result(p3 != NULL || p3 == NULL, "my_calloc(0, 0) returns valid result");
+//     if (p1) my_free(p1);
+//     if (p2) my_free(p2);
+//     if (p3) my_free(p3);
     
-//     // Test 2: calloc simple avec vérification de zéro
-//     char *ptr = calloc(10, sizeof(char));
-//     test_result(ptr != NULL, "calloc(10, sizeof(char)) succeeds");
+//     // Test 2: my_calloc simple avec vérification de zéro
+//     char *ptr = my_calloc(10, sizeof(char));
+//     test_result(ptr != NULL, "my_calloc(10, sizeof(char)) succeeds");
     
 //     if (ptr) {
 //         int all_zero = 1;
@@ -493,14 +493,14 @@
 //                 break;
 //             }
 //         }
-//         test_result(all_zero, "calloc initializes memory to zero");
-//         test_result(((uintptr_t)ptr % 8) == 0, "calloc result is 8-byte aligned");
-//         free(ptr);
+//         test_result(all_zero, "my_calloc initializes memory to zero");
+//         test_result(((uintptr_t)ptr % 8) == 0, "my_calloc result is 8-byte aligned");
+//         my_free(ptr);
 //     }
     
-//     // Test 3: calloc avec différentes tailles
-//     int *int_arr = calloc(100, sizeof(int));
-//     test_result(int_arr != NULL, "calloc(100, sizeof(int)) succeeds");
+//     // Test 3: my_calloc avec différentes tailles
+//     int *int_arr = my_calloc(100, sizeof(int));
+//     test_result(int_arr != NULL, "my_calloc(100, sizeof(int)) succeeds");
 //     if (int_arr) {
 //         int all_zero = 1;
 //         for (int i = 0; i < 100; i++) {
@@ -509,13 +509,13 @@
 //                 break;
 //             }
 //         }
-//         test_result(all_zero, "calloc int array initialized to zero");
-//         free(int_arr);
+//         test_result(all_zero, "my_calloc int array initialized to zero");
+//         my_free(int_arr);
 //     }
     
-//     // Test 4: calloc TINY
-//     char *tiny = calloc(64, 1);
-//     test_result(tiny != NULL, "calloc TINY (64 bytes) succeeds");
+//     // Test 4: my_calloc TINY
+//     char *tiny = my_calloc(64, 1);
+//     test_result(tiny != NULL, "my_calloc TINY (64 bytes) succeeds");
 //     if (tiny) {
 //         int all_zero = 1;
 //         for (int i = 0; i < 64; i++) {
@@ -524,19 +524,19 @@
 //                 break;
 //             }
 //         }
-//         test_result(all_zero, "calloc TINY initialized to zero");
-//         free(tiny);
+//         test_result(all_zero, "my_calloc TINY initialized to zero");
+//         my_free(tiny);
 //     }
     
 //     show_alloc_mem();
 // }
 
 // void test_calloc_sizes() {
-//     TEST_SECTION("calloc SIZE CATEGORIES");
+//     TEST_SECTION("my_calloc SIZE CATEGORIES");
     
 //     // Test TINY (≤ 128 bytes)
-//     char *tiny = calloc(32, 4); // 128 bytes exactly
-//     test_result(tiny != NULL, "calloc TINY boundary (32*4=128) succeeds");
+//     char *tiny = my_calloc(32, 4); // 128 bytes exactly
+//     test_result(tiny != NULL, "my_calloc TINY boundary (32*4=128) succeeds");
 //     if (tiny) {
 //         int all_zero = 1;
 //         for (int i = 0; i < 128; i++) {
@@ -545,13 +545,13 @@
 //                 break;
 //             }
 //         }
-//         test_result(all_zero, "calloc TINY boundary zeroed");
-//         free(tiny);
+//         test_result(all_zero, "my_calloc TINY boundary zeroed");
+//         my_free(tiny);
 //     }
     
 //     // Test SMALL (129-1024 bytes)
-//     short *small = calloc(200, sizeof(short)); // 400 bytes
-//     test_result(small != NULL, "calloc SMALL (200*2=400) succeeds");
+//     short *small = my_calloc(200, sizeof(short)); // 400 bytes
+//     test_result(small != NULL, "my_calloc SMALL (200*2=400) succeeds");
 //     if (small) {
 //         int all_zero = 1;
 //         for (int i = 0; i < 200; i++) {
@@ -560,13 +560,13 @@
 //                 break;
 //             }
 //         }
-//         test_result(all_zero, "calloc SMALL zeroed");
-//         free(small);
+//         test_result(all_zero, "my_calloc SMALL zeroed");
+//         my_free(small);
 //     }
     
 //     // Test LARGE (> 1024 bytes)
-//     long *large = calloc(300, sizeof(long)); // 2400 bytes sur 64-bit
-//     test_result(large != NULL, "calloc LARGE (300*8=2400) succeeds");
+//     long *large = my_calloc(300, sizeof(long)); // 2400 bytes sur 64-bit
+//     test_result(large != NULL, "my_calloc LARGE (300*8=2400) succeeds");
 //     if (large) {
 //         int all_zero = 1;
 //         for (int i = 0; i < 300; i++) {
@@ -575,41 +575,41 @@
 //                 break;
 //             }
 //         }
-//         test_result(all_zero, "calloc LARGE zeroed");
-//         free(large);
+//         test_result(all_zero, "my_calloc LARGE zeroed");
+//         my_free(large);
 //     }
     
 //     show_alloc_mem();
 // }
 
 // void test_calloc_overflow() {
-//     TEST_SECTION("calloc OVERFLOW TESTS");
+//     TEST_SECTION("my_calloc OVERFLOW TESTS");
     
 //     // Test overflow detection
 //     size_t huge = SIZE_MAX / 2;
-//     void *overflow1 = calloc(huge, huge);
-//     test_result(overflow1 == NULL, "calloc overflow detection (huge * huge)");
-//     if (overflow1) free(overflow1);
+//     void *overflow1 = my_calloc(huge, huge);
+//     test_result(overflow1 == NULL, "my_calloc overflow detection (huge * huge)");
+//     if (overflow1) my_free(overflow1);
     
 //     // Test autre cas d'overflow
-//     void *overflow2 = calloc(SIZE_MAX, 2);
-//     test_result(overflow2 == NULL, "calloc overflow detection (SIZE_MAX * 2)");
-//     if (overflow2) free(overflow2);
+//     void *overflow2 = my_calloc(SIZE_MAX, 2);
+//     test_result(overflow2 == NULL, "my_calloc overflow detection (SIZE_MAX * 2)");
+//     if (overflow2) my_free(overflow2);
     
 //     // Test cas limite mais valide
-//     void *valid = calloc(1000, 1000); // 1MB
-//     test_result(valid != NULL, "calloc large but valid allocation");
+//     void *valid = my_calloc(1000, 1000); // 1MB
+//     test_result(valid != NULL, "my_calloc large but valid allocation");
 //     if (valid) {
 //         // Vérifier quelques positions aléatoirement
 //         char *ptr = (char*)valid;
 //         int sample_zero = (ptr[0] == 0 && ptr[500000] == 0 && ptr[999999] == 0);
-//         test_result(sample_zero, "calloc large allocation properly zeroed");
-//         free(valid);
+//         test_result(sample_zero, "my_calloc large allocation properly zeroed");
+//         my_free(valid);
 //     }
 // }
 
 // void test_calloc_patterns() {
-//     TEST_SECTION("calloc PATTERN TESTS");
+//     TEST_SECTION("my_calloc PATTERN TESTS");
     
 //     // Test avec structures complexes
 //     struct test_struct {
@@ -619,8 +619,8 @@
 //         void *ptr;
 //     };
     
-//     struct test_struct *structs = calloc(10, sizeof(struct test_struct));
-//     test_result(structs != NULL, "calloc struct array succeeds");
+//     struct test_struct *structs = my_calloc(10, sizeof(struct test_struct));
+//     test_result(structs != NULL, "my_calloc struct array succeeds");
     
 //     if (structs) {
 //         int all_zero = 1;
@@ -636,14 +636,14 @@
 //                 }
 //             }
 //         }
-//         test_result(all_zero, "calloc struct array properly zeroed");
-//         free(structs);
+//         test_result(all_zero, "my_calloc struct array properly zeroed");
+//         my_free(structs);
 //     }
     
-//     // Test calloc avec différents patterns de taille
+//     // Test my_calloc avec différents patterns de taille
 //     for (int size = 1; size <= 10; size++) {
-//         void *ptr = calloc(size, 100);
-//         test_result(ptr != NULL, "calloc variable sizes succeeds");
+//         void *ptr = my_calloc(size, 100);
+//         test_result(ptr != NULL, "my_calloc variable sizes succeeds");
 //         if (ptr) {
 //             char *cptr = (char*)ptr;
 //             int is_zero = 1;
@@ -653,38 +653,38 @@
 //                     break;
 //                 }
 //             }
-//             test_result(is_zero, "calloc variable sizes properly zeroed");
-//             free(ptr);
+//             test_result(is_zero, "my_calloc variable sizes properly zeroed");
+//             my_free(ptr);
 //         }
 //     }
 // }
 
 // void test_calloc_extreme() {
-//     TEST_SECTION("calloc EXTREME TESTS");
+//     TEST_SECTION("my_calloc EXTREME TESTS");
     
-//     // Test calloc(1, very_large)
-//     void *big1 = calloc(1, 1024 * 1024); // 1MB
-//     test_result(big1 != NULL, "calloc(1, 1MB) succeeds");
+//     // Test my_calloc(1, very_large)
+//     void *big1 = my_calloc(1, 1024 * 1024); // 1MB
+//     test_result(big1 != NULL, "my_calloc(1, 1MB) succeeds");
 //     if (big1) {
 //         char *ptr = (char*)big1;
 //         int samples_zero = (ptr[0] == 0 && ptr[512*1024] == 0 && ptr[1024*1024-1] == 0);
-//         test_result(samples_zero, "calloc(1, 1MB) properly zeroed");
-//         free(big1);
+//         test_result(samples_zero, "my_calloc(1, 1MB) properly zeroed");
+//         my_free(big1);
 //     }
     
-//     // Test calloc(very_large, 1)
-//     void *big2 = calloc(1024 * 1024, 1); // 1MB
-//     test_result(big2 != NULL, "calloc(1MB, 1) succeeds");
+//     // Test my_calloc(very_large, 1)
+//     void *big2 = my_calloc(1024 * 1024, 1); // 1MB
+//     test_result(big2 != NULL, "my_calloc(1MB, 1) succeeds");
 //     if (big2) {
 //         char *ptr = (char*)big2;
 //         int samples_zero = (ptr[0] == 0 && ptr[512*1024] == 0 && ptr[1024*1024-1] == 0);
-//         test_result(samples_zero, "calloc(1MB, 1) properly zeroed");
-//         free(big2);
+//         test_result(samples_zero, "my_calloc(1MB, 1) properly zeroed");
+//         my_free(big2);
 //     }
     
-//     // Test calloc avec des tailles premières
-//     void *prime = calloc(97, 101); // 9797 bytes
-//     test_result(prime != NULL, "calloc(97, 101) prime numbers succeeds");
+//     // Test my_calloc avec des tailles premières
+//     void *prime = my_calloc(97, 101); // 9797 bytes
+//     test_result(prime != NULL, "my_calloc(97, 101) prime numbers succeeds");
 //     if (prime) {
 //         char *ptr = (char*)prime;
 //         int all_zero = 1;
@@ -694,8 +694,8 @@
 //                 break;
 //             }
 //         }
-//         test_result(all_zero, "calloc prime numbers properly zeroed");
-//         free(prime);
+//         test_result(all_zero, "my_calloc prime numbers properly zeroed");
+//         my_free(prime);
 //     }
     
 //     show_alloc_mem();
@@ -704,9 +704,9 @@
 // void test_reallocarray_basic() {
 //     TEST_SECTION("reallocARRAY BASIC TESTS");
     
-//     // Test 1: reallocarray(NULL, nmemb, size) = calloc(nmemb, size)
-//     int *arr = reallocarray(NULL, 10, sizeof(int));
-//     test_result(arr != NULL, "reallocarray(NULL, 10, sizeof(int)) succeeds");
+//     // Test 1: my_reallocarray(NULL, nmemb, size) = my_calloc(nmemb, size)
+//     int *arr = my_reallocarray(NULL, 10, sizeof(int));
+//     test_result(arr != NULL, "my_reallocarray(NULL, 10, sizeof(int)) succeeds");
     
 //     if (arr) {
 //         // Initialiser avec des valeurs
@@ -722,11 +722,11 @@
 //                 break;
 //             }
 //         }
-//         test_result(values_ok, "reallocarray initial data integrity");
+//         test_result(values_ok, "my_reallocarray initial data integrity");
         
 //         // Test 2: agrandir le tableau
-//         arr = reallocarray(arr, 20, sizeof(int));
-//         test_result(arr != NULL, "reallocarray expand (10->20) succeeds");
+//         arr = my_reallocarray(arr, 20, sizeof(int));
+//         test_result(arr != NULL, "my_reallocarray expand (10->20) succeeds");
         
 //         if (arr) {
 //             // Vérifier que les anciennes données sont préservées
@@ -737,7 +737,7 @@
 //                     break;
 //                 }
 //             }
-//             test_result(old_data_ok, "reallocarray preserves old data on expand");
+//             test_result(old_data_ok, "my_reallocarray preserves old data on expand");
             
 //             // Initialiser les nouveaux éléments
 //             for (int i = 10; i < 20; i++) {
@@ -745,8 +745,8 @@
 //             }
             
 //             // Test 3: réduire le tableau
-//             arr = reallocarray(arr, 15, sizeof(int));
-//             test_result(arr != NULL, "reallocarray shrink (20->15) succeeds");
+//             arr = my_reallocarray(arr, 15, sizeof(int));
+//             test_result(arr != NULL, "my_reallocarray shrink (20->15) succeeds");
             
 //             if (arr) {
 //                 // Vérifier les données restantes
@@ -763,9 +763,9 @@
 //                         break;
 //                     }
 //                 }
-//                 test_result(remaining_data_ok, "reallocarray preserves data on shrink");
+//                 test_result(remaining_data_ok, "my_reallocarray preserves data on shrink");
                 
-//                 free(arr);
+//                 my_free(arr);
 //             }
 //         }
 //     }
@@ -777,53 +777,53 @@
 //     TEST_SECTION("reallocARRAY OVERFLOW TESTS");
     
 //     // Test overflow detection avec un pointeur existant
-//     void *ptr = calloc(100, 1);
+//     void *ptr = my_calloc(100, 1);
 //     if (ptr) {
 //         strcpy((char*)ptr, "Test data");
         
 //         // Tentative d'overflow
-//         void *overflow1 = reallocarray(ptr, SIZE_MAX/2, SIZE_MAX/2);
-//         test_result(overflow1 == NULL, "reallocarray overflow detection (huge*huge)");
+//         void *overflow1 = my_reallocarray(ptr, SIZE_MAX/2, SIZE_MAX/2);
+//         test_result(overflow1 == NULL, "my_reallocarray overflow detection (huge*huge)");
         
-//         // Le pointeur original doit rester valide si reallocarray échoue
+//         // Le pointeur original doit rester valide si my_reallocarray échoue
 //         if (overflow1 == NULL) {
 //             test_result(strcmp((char*)ptr, "Test data") == 0, "Original pointer valid after overflow");
 //         }
         
 //         // Test autre cas d'overflow
-//         void *overflow2 = reallocarray(ptr, SIZE_MAX, 2);
-//         test_result(overflow2 == NULL, "reallocarray overflow detection (SIZE_MAX*2)");
+//         void *overflow2 = my_reallocarray(ptr, SIZE_MAX, 2);
+//         test_result(overflow2 == NULL, "my_reallocarray overflow detection (SIZE_MAX*2)");
 //         if (overflow2 == NULL) {
 //             test_result(strcmp((char*)ptr, "Test data") == 0, "Original pointer still valid");
 //         }
         
-//         free(ptr);
+//         my_free(ptr);
 //     }
     
-//     // Test reallocarray(NULL, overflow_values)
-//     void *overflow3 = reallocarray(NULL, SIZE_MAX, SIZE_MAX);
-//     test_result(overflow3 == NULL, "reallocarray(NULL, overflow) fails safely");
-//     if (overflow3) free(overflow3);
+//     // Test my_reallocarray(NULL, overflow_values)
+//     void *overflow3 = my_reallocarray(NULL, SIZE_MAX, SIZE_MAX);
+//     test_result(overflow3 == NULL, "my_reallocarray(NULL, overflow) fails safely");
+//     if (overflow3) my_free(overflow3);
     
 //     // Test cas limite valide
-//     void *valid = reallocarray(NULL, 1000, 1000); // 1MB
-//     test_result(valid != NULL, "reallocarray large but valid allocation");
-//     if (valid) free(valid);
+//     void *valid = my_reallocarray(NULL, 1000, 1000); // 1MB
+//     test_result(valid != NULL, "my_reallocarray large but valid allocation");
+//     if (valid) my_free(valid);
 // }
 
 // void test_reallocarray_categories() {
 //     TEST_SECTION("reallocARRAY SIZE CATEGORIES");
     
 //     // TINY -> SMALL
-//     char *ptr = reallocarray(NULL, 64, 1); // 64 bytes TINY
-//     test_result(ptr != NULL, "reallocarray TINY (64*1) succeeds");
+//     char *ptr = my_reallocarray(NULL, 64, 1); // 64 bytes TINY
+//     test_result(ptr != NULL, "my_reallocarray TINY (64*1) succeeds");
     
 //     if (ptr) {
 //         memset(ptr, 'T', 64);
         
 //         // Passer à SMALL
-//         ptr = reallocarray(ptr, 200, 1); // 200 bytes SMALL
-//         test_result(ptr != NULL, "reallocarray TINY->SMALL succeeds");
+//         ptr = my_reallocarray(ptr, 200, 1); // 200 bytes SMALL
+//         test_result(ptr != NULL, "my_reallocarray TINY->SMALL succeeds");
         
 //         if (ptr) {
 //             int data_ok = 1;
@@ -833,14 +833,14 @@
 //                     break;
 //                 }
 //             }
-//             test_result(data_ok, "reallocarray TINY->SMALL preserves data");
+//             test_result(data_ok, "my_reallocarray TINY->SMALL preserves data");
             
 //             // Remplir le reste
 //             memset(ptr + 64, 'S', 136);
             
 //             // Passer à LARGE
-//             ptr = reallocarray(ptr, 2048, 1); // 2048 bytes LARGE
-//             test_result(ptr != NULL, "reallocarray SMALL->LARGE succeeds");
+//             ptr = my_reallocarray(ptr, 2048, 1); // 2048 bytes LARGE
+//             test_result(ptr != NULL, "my_reallocarray SMALL->LARGE succeeds");
             
 //             if (ptr) {
 //                 int data_ok = 1;
@@ -856,11 +856,11 @@
 //                         break;
 //                     }
 //                 }
-//                 test_result(data_ok, "reallocarray SMALL->LARGE preserves data");
+//                 test_result(data_ok, "my_reallocarray SMALL->LARGE preserves data");
                 
 //                 // Test retour LARGE -> SMALL
-//                 ptr = reallocarray(ptr, 512, 1); // 512 bytes SMALL
-//                 test_result(ptr != NULL, "reallocarray LARGE->SMALL succeeds");
+//                 ptr = my_reallocarray(ptr, 512, 1); // 512 bytes SMALL
+//                 test_result(ptr != NULL, "my_reallocarray LARGE->SMALL succeeds");
                 
 //                 if (ptr) {
 //                     int data_ok = 1;
@@ -876,11 +876,11 @@
 //                             break;
 //                         }
 //                     }
-//                     test_result(data_ok, "reallocarray LARGE->SMALL preserves data");
+//                     test_result(data_ok, "my_reallocarray LARGE->SMALL preserves data");
                     
 //                     // Test retour SMALL -> TINY
-//                     ptr = reallocarray(ptr, 100, 1); // 100 bytes TINY
-//                     test_result(ptr != NULL, "reallocarray SMALL->TINY succeeds");
+//                     ptr = my_reallocarray(ptr, 100, 1); // 100 bytes TINY
+//                     test_result(ptr != NULL, "my_reallocarray SMALL->TINY succeeds");
                     
 //                     if (ptr) {
 //                         int data_ok = 1;
@@ -896,9 +896,9 @@
 //                                 break;
 //                             }
 //                         }
-//                         test_result(data_ok, "reallocarray SMALL->TINY preserves data");
+//                         test_result(data_ok, "my_reallocarray SMALL->TINY preserves data");
                         
-//                         free(ptr);
+//                         my_free(ptr);
 //                     }
 //                 }
 //             }
@@ -909,43 +909,43 @@
 // void test_reallocarray_edge_cases() {
 //     TEST_SECTION("reallocARRAY EDGE CASES");
     
-//     // Test reallocarray(ptr, 0, size) 
-//     void *ptr = calloc(100, 1);
+//     // Test my_reallocarray(ptr, 0, size) 
+//     void *ptr = my_calloc(100, 1);
 //     if (ptr) {
 //         strcpy((char*)ptr, "Edge test");
         
-//         void *result1 = reallocarray(ptr, 0, 10);
-//         test_result(result1 != NULL || result1 == NULL, "reallocarray(ptr, 0, 10) returns valid result");
+//         void *result1 = my_reallocarray(ptr, 0, 10);
+//         test_result(result1 != NULL || result1 == NULL, "my_reallocarray(ptr, 0, 10) returns valid result");
         
-//             free(result1);
+//             my_free(result1);
 //             ptr = NULL; // ptr a été libéré
 //     }
     
-//     // Test reallocarray(ptr, nmemb, 0)
+//     // Test my_reallocarray(ptr, nmemb, 0)
 //     if (!ptr) {
-//         ptr = calloc(100, 1);
+//         ptr = my_calloc(100, 1);
 //         strcpy((char*)ptr, "Edge test 2");
 //     }
     
 //     if (ptr) {
-//         void *result2 = reallocarray(ptr, 10, 0);
-//         test_result(result2 != NULL || result2 == NULL, "reallocarray(ptr, 10, 0) returns valid result");
+//         void *result2 = my_reallocarray(ptr, 10, 0);
+//         test_result(result2 != NULL || result2 == NULL, "my_reallocarray(ptr, 10, 0) returns valid result");
         
 //         if (result2) {
-//             free(result2);
+//             my_free(result2);
 //         }
 // 		ptr = NULL;
 //     }
     
-//     // Test reallocarray same size
-//     double *darr = reallocarray(NULL, 50, sizeof(double));
+//     // Test my_reallocarray same size
+//     double *darr = my_reallocarray(NULL, 50, sizeof(double));
 //     if (darr) {
 //         for (int i = 0; i < 50; i++) {
 //             darr[i] = i * 3.14;
 //         }
         
-//         double *same = reallocarray(darr, 50, sizeof(double));
-//         test_result(same != NULL, "reallocarray same size succeeds");
+//         double *same = my_reallocarray(darr, 50, sizeof(double));
+//         test_result(same != NULL, "my_reallocarray same size succeeds");
         
 //         if (same) {
 //             int data_ok = 1;
@@ -955,18 +955,18 @@
 //                     break;
 //                 }
 //             }
-//             test_result(data_ok, "reallocarray same size preserves data");
-//             free(same);
+//             test_result(data_ok, "my_reallocarray same size preserves data");
+//             my_free(same);
 //         }
 //     }
     
-//     // Test reallocarray(NULL, 1, 1)
-//     void *minimal = reallocarray(NULL, 1, 1);
-//     test_result(minimal != NULL, "reallocarray(NULL, 1, 1) succeeds");
+//     // Test my_reallocarray(NULL, 1, 1)
+//     void *minimal = my_reallocarray(NULL, 1, 1);
+//     test_result(minimal != NULL, "my_reallocarray(NULL, 1, 1) succeeds");
 //     if (minimal) {
 //         *(char*)minimal = 'X';
-//         test_result(*(char*)minimal == 'X', "reallocarray minimal allocation works");
-//         free(minimal);
+//         test_result(*(char*)minimal == 'X', "my_reallocarray minimal allocation works");
+//         my_free(minimal);
 //     }
 // }
 
@@ -985,7 +985,7 @@
 //     for (int round = 0; round < num_sizes; round++) {
 //         size_t new_size = sizes[round];
         
-//         dynamic_arr = reallocarray(dynamic_arr, new_size, sizeof(int));
+//         dynamic_arr = my_reallocarray(dynamic_arr, new_size, sizeof(int));
 //         if (!dynamic_arr) {
 //             stress_ok = 0;
 //             break;
@@ -1013,10 +1013,10 @@
 //         current_size = new_size;
 //     }
     
-//     test_result(stress_ok, "reallocarray stress test completes");
+//     test_result(stress_ok, "my_reallocarray stress test completes");
     
 //     if (dynamic_arr) {
-//         free(dynamic_arr);
+//         my_free(dynamic_arr);
 //     }
 // }
 
@@ -1030,8 +1030,8 @@
 //         int checksum;
 //     };
     
-//     struct data_block *blocks = reallocarray(NULL, 10, sizeof(struct data_block));
-//     test_result(blocks != NULL, "reallocarray data blocks allocation");
+//     struct data_block *blocks = my_reallocarray(NULL, 10, sizeof(struct data_block));
+//     test_result(blocks != NULL, "my_reallocarray data blocks allocation");
     
 //     if (blocks) {
 //         // Initialiser avec un pattern reconnaissable
@@ -1042,8 +1042,8 @@
 //         }
         
 //         // Agrandir le tableau
-//         blocks = reallocarray(blocks, 20, sizeof(struct data_block));
-//         test_result(blocks != NULL, "reallocarray data blocks expansion");
+//         blocks = my_reallocarray(blocks, 20, sizeof(struct data_block));
+//         test_result(blocks != NULL, "my_reallocarray data blocks expansion");
         
 //         if (blocks) {
 //             // Vérifier l'intégrité des données originales
@@ -1061,19 +1061,19 @@
 //                 }
 //                 if (!integrity_ok) break;
 //             }
-//             test_result(integrity_ok, "reallocarray preserves complex data structures");
+//             test_result(integrity_ok, "my_reallocarray preserves complex data structures");
             
-//             free(blocks);
+//             my_free(blocks);
 //         }
 //     }
 // }
 
 // void test_calloc_reallocarray_interaction() {
-//     TEST_SECTION("calloc + reallocARRAY INTERACTION");
+//     TEST_SECTION("my_calloc + reallocARRAY INTERACTION");
     
-//     // Créer un tableau avec calloc
-//     long *arr = calloc(20, sizeof(long));
-//     test_result(arr != NULL, "calloc(20, sizeof(long)) for interaction test");
+//     // Créer un tableau avec my_calloc
+//     long *arr = my_calloc(20, sizeof(long));
+//     test_result(arr != NULL, "my_calloc(20, sizeof(long)) for interaction test");
     
 //     if (arr) {
 //         // Vérifier qu'il est à zéro
@@ -1084,16 +1084,16 @@
 //                 break;
 //             }
 //         }
-//         test_result(all_zero, "calloc result is zeroed before reallocarray");
+//         test_result(all_zero, "my_calloc result is zeroed before my_reallocarray");
         
 //         // Modifier quelques valeurs
 //         for (int i = 0; i < 20; i++) {
 //             arr[i] = i * 100;
 //         }
         
-//         // Utiliser reallocarray pour agrandir
-//         arr = reallocarray(arr, 40, sizeof(long));
-//         test_result(arr != NULL, "reallocarray after calloc succeeds");
+//         // Utiliser my_reallocarray pour agrandir
+//         arr = my_reallocarray(arr, 40, sizeof(long));
+//         test_result(arr != NULL, "my_reallocarray after my_calloc succeeds");
         
 //         if (arr) {
 //             // Vérifier que les données originales sont préservées
@@ -1104,15 +1104,15 @@
 //                     break;
 //                 }
 //             }
-//             test_result(data_preserved, "reallocarray preserves calloc'd data");
+//             test_result(data_preserved, "my_reallocarray preserves my_calloc'd data");
             
-//             free(arr);
+//             my_free(arr);
 //         }
 //     }
     
-//     // Test inverse: reallocarray puis comparaison avec calloc
-//     char *buf1 = reallocarray(NULL, 100, sizeof(char));
-//     char *buf2 = calloc(100, sizeof(char));
+//     // Test inverse: my_reallocarray puis comparaison avec my_calloc
+//     char *buf1 = my_reallocarray(NULL, 100, sizeof(char));
+//     char *buf2 = my_calloc(100, sizeof(char));
     
 //     if (buf1 && buf2) {
 //         // buf2 devrait être à zéro, buf1 pas nécessairement
@@ -1123,10 +1123,10 @@
 //                 break;
 //             }
 //         }
-//         test_result(buf2_zero, "calloc vs reallocarray: calloc is zeroed");
+//         test_result(buf2_zero, "my_calloc vs my_reallocarray: my_calloc is zeroed");
         
-//         free(buf1);
-//         free(buf2);
+//         my_free(buf1);
+//         my_free(buf2);
 //     }
 // }
 
@@ -1134,39 +1134,39 @@
 //     TEST_SECTION("reallocARRAY BOUNDARY TESTS");
     
 //     // Tests aux limites exactes des catégories
-//     void *tiny_max = reallocarray(NULL, 128, 1); // Max TINY
-//     void *small_min = reallocarray(NULL, 129, 1); // Min SMALL  
-//     void *small_max = reallocarray(NULL, 1024, 1); // Max SMALL
-//     void *large_min = reallocarray(NULL, 1025, 1); // Min LARGE
+//     void *tiny_max = my_reallocarray(NULL, 128, 1); // Max TINY
+//     void *small_min = my_reallocarray(NULL, 129, 1); // Min SMALL  
+//     void *small_max = my_reallocarray(NULL, 1024, 1); // Max SMALL
+//     void *large_min = my_reallocarray(NULL, 1025, 1); // Min LARGE
     
-//     test_result(tiny_max != NULL, "reallocarray TINY max boundary (128)");
-//     test_result(small_min != NULL, "reallocarray SMALL min boundary (129)");
-//     test_result(small_max != NULL, "reallocarray SMALL max boundary (1024)");
-//     test_result(large_min != NULL, "reallocarray LARGE min boundary (1025)");
+//     test_result(tiny_max != NULL, "my_reallocarray TINY max boundary (128)");
+//     test_result(small_min != NULL, "my_reallocarray SMALL min boundary (129)");
+//     test_result(small_max != NULL, "my_reallocarray SMALL max boundary (1024)");
+//     test_result(large_min != NULL, "my_reallocarray LARGE min boundary (1025)");
     
 //     // Test d'écriture dans chaque bloc
 //     if (tiny_max) {
 //         memset(tiny_max, 'T', 128);
 //         test_result(((char*)tiny_max)[127] == 'T', "TINY boundary block writable");
-//         free(tiny_max);
+//         my_free(tiny_max);
 //     }
     
 //     if (small_min) {
 //         memset(small_min, 'S', 129);
 //         test_result(((char*)small_min)[128] == 'S', "SMALL min boundary block writable");
-//         free(small_min);
+//         my_free(small_min);
 //     }
     
 //     if (small_max) {
 //         memset(small_max, 'M', 1024);
 //         test_result(((char*)small_max)[1023] == 'M', "SMALL max boundary block writable");
-//         free(small_max);
+//         my_free(small_max);
 //     }
     
 //     if (large_min) {
 //         memset(large_min, 'L', 1025);
 //         test_result(((char*)large_min)[1024] == 'L', "LARGE min boundary block writable");
-//         free(large_min);
+//         my_free(large_min);
 //     }
     
 //     show_alloc_mem();
@@ -1182,7 +1182,7 @@
 //         test_result(strlen(empty) == 0, "strdup(\"\") returns empty string");
 //         test_result(strcmp(empty, "") == 0, "strdup(\"\") content is correct");
 //         test_result(((uintptr_t)empty % 8) == 0, "strdup(\"\") result is 8-byte aligned");
-//         free(empty);
+//         my_free(empty);
 //     }
     
 //     // Test 2: chaîne simple
@@ -1192,7 +1192,7 @@
 //         test_result(strlen(simple) == 5, "strdup(\"Hello\") length is correct");
 //         test_result(strcmp(simple, "Hello") == 0, "strdup(\"Hello\") content is correct");
 //         test_result(((uintptr_t)simple % 8) == 0, "strdup(\"Hello\") result is 8-byte aligned");
-//         free(simple);
+//         my_free(simple);
 //     }
     
 //     // Test 3: chaîne longue
@@ -1202,7 +1202,7 @@
 //         test_result(strlen(long_str) == 44, "strdup(long string) length is correct");
 //         test_result(strcmp(long_str, "This is a longer string for testing purposes") == 0, 
 //                    "strdup(long string) content is correct");
-//         free(long_str);
+//         my_free(long_str);
 //     }
     
 //     // Test 4: chaîne avec caractères spéciaux
@@ -1211,7 +1211,7 @@
 //     if (special) {
 //         test_result(strcmp(special, "Hello\tWorld\n\r\\\"") == 0, 
 //                    "strdup(special chars) content is correct");
-//         free(special);
+//         my_free(special);
 //     }
     
 //     show_alloc_mem();
@@ -1232,7 +1232,7 @@
 //         test_result(strlen(tiny) == 64, "strdup TINY length correct");
 //         test_result(strcmp(tiny, tiny_source) == 0, "strdup TINY content correct");
 //         test_result(tiny[63] == 'A' && tiny[64] == '\0', "strdup TINY null termination");
-//         free(tiny);
+//         my_free(tiny);
 //     }
     
 //     // Chaîne exactement à la limite TINY (127 chars + \0 = 128 bytes)
@@ -1245,7 +1245,7 @@
 //     if (tiny_max) {
 //         test_result(strlen(tiny_max) == 127, "strdup TINY max length correct");
 //         test_result(strcmp(tiny_max, tiny_max_source) == 0, "strdup TINY max content correct");
-//         free(tiny_max);
+//         my_free(tiny_max);
 //     }
     
 //     // Test SMALL (129-1024 bytes) - 200 caractères
@@ -1258,7 +1258,7 @@
 //     if (small) {
 //         test_result(strlen(small) == 200, "strdup SMALL length correct");
 //         test_result(strcmp(small, small_source) == 0, "strdup SMALL content correct");
-//         free(small);
+//         my_free(small);
 //     }
     
 //     // Chaîne à la limite SMALL (1023 chars + \0 = 1024 bytes)
@@ -1272,7 +1272,7 @@
 //         test_result(strlen(small_max) == 1023, "strdup SMALL max length correct");
 //         test_result(small_max[1022] == 'M' && small_max[1023] == '\0', 
 //                    "strdup SMALL max termination correct");
-//         free(small_max);
+//         my_free(small_max);
 //     }
     
 //     // Test LARGE (> 1024 bytes) - 2000 caractères
@@ -1286,7 +1286,7 @@
 //         test_result(strlen(large) == 2000, "strdup LARGE length correct");
 //         test_result(large[1999] == 'L' && large[2000] == '\0', 
 //                    "strdup LARGE content and termination correct");
-//         free(large);
+//         my_free(large);
 //     }
     
 //     show_alloc_mem();
@@ -1317,7 +1317,7 @@
 //             }
 //         }
 //         test_result(char_by_char_ok, "strdup ASCII char-by-char integrity");
-//         free(ascii_copy);
+//         my_free(ascii_copy);
 //     }
     
 //     // Test avec des octets binaires (incluant des 0 dans la chaîne source jusqu'au premier \0)
@@ -1328,7 +1328,7 @@
 //         test_result(strcmp(binary_copy, binary_source) == 0, "strdup binary content correct");
 //         test_result(binary_copy[6] == '\x01' && binary_copy[7] == '\x02', 
 //                    "strdup preserves binary values");
-//         free(binary_copy);
+//         my_free(binary_copy);
 //     }
     
 //     // Test avec répétition de patterns
@@ -1350,7 +1350,7 @@
 //             }
 //         }
 //         test_result(pattern_ok, "strdup pattern content integrity");
-//         free(pattern_copy);
+//         my_free(pattern_copy);
 //     }
 // }
 
@@ -1378,7 +1378,7 @@
 //         test_result(strcmp(copy, "Modified copy") == 0, 
 //                    "strdup copy modification successful");
         
-//         free(copy);
+//         my_free(copy);
 //     }
     
 //     // Test avec buffer temporaire
@@ -1395,7 +1395,7 @@
 //     if (dynamic_copy) {
 //         test_result(strcmp(dynamic_copy, "Temporary buffer content") == 0, 
 //                    "strdup copy survives original buffer destruction");
-//         free(dynamic_copy);
+//         my_free(dynamic_copy);
 //     }
 // }
 
@@ -1408,11 +1408,11 @@
 //     if (single) {
 //         test_result(strlen(single) == 1, "strdup single char length correct");
 //         test_result(single[0] == 'X' && single[1] == '\0', "strdup single char content correct");
-//         free(single);
+//         my_free(single);
 //     }
     
 //     // Test chaîne très longue (10KB)
-//     char *big_source = malloc(10241);
+//     char *big_source = my_malloc(10241);
 //     if (big_source) {
 //         memset(big_source, 'B', 10240);
 //         big_source[10240] = '\0';
@@ -1428,9 +1428,9 @@
 //             int sample_ok = (big_copy[1000] == 'B' && big_copy[5000] == 'B' && big_copy[9000] == 'B');
 //             test_result(sample_ok, "strdup large string sample positions correct");
             
-//             free(big_copy);
+//             my_free(big_copy);
 //         }
-//         free(big_source);
+//         my_free(big_source);
 //     }
     
 //     // Test avec une chaîne contenant beaucoup d'espaces
@@ -1450,7 +1450,7 @@
 //             }
 //         }
 //         test_result(all_spaces && spaces_copy[1000] == '\0', "strdup spaces content correct");
-//         free(spaces_copy);
+//         my_free(spaces_copy);
 //     }
 // }
 
@@ -1462,7 +1462,7 @@
 //     test_result(utf8 != NULL, "strdup UTF-8 chars succeeds");
 //     if (utf8) {
 //         test_result(strcmp(utf8, "Héllo Wörld! 🌍 café") == 0, "strdup UTF-8 content correct");
-//         free(utf8);
+//         my_free(utf8);
 //     }
     
 //     // Test avec tous les caractères de contrôle ASCII (0-31)
@@ -1484,7 +1484,7 @@
 //             }
 //         }
 //         test_result(control_ok, "strdup control chars content correct");
-//         free(control_copy);
+//         my_free(control_copy);
 //     }
     
 //     // Test avec caractères de fin de ligne variés
@@ -1493,7 +1493,7 @@
 //     if (newlines) {
 //         test_result(strcmp(newlines, "Line1\nLine2\rLine3\r\nLine4") == 0, 
 //                    "strdup newline variants content correct");
-//         free(newlines);
+//         my_free(newlines);
 //     }
     
 //     // Test avec guillemets et échappements
@@ -1502,7 +1502,7 @@
 //     if (quotes) {
 //         test_result(strcmp(quotes, "\"Hello\" 'World' \\backslash\\") == 0, 
 //                    "strdup quotes and escapes content correct");
-//         free(quotes);
+//         my_free(quotes);
 //     }
 // }
 
@@ -1532,7 +1532,7 @@
     
 //     for (int i = 0; i < 10; i++) {
 //         if (ptrs[i]) {
-//             free(ptrs[i]);
+//             my_free(ptrs[i]);
 //         }
 //     }
 // }
@@ -1542,7 +1542,7 @@
     
 //     // Allouer beaucoup de chaînes de tailles variées
 //     const int num_strings = 1000;
-//     char **strings = malloc(num_strings * sizeof(char*));
+//     char **strings = my_malloc(num_strings * sizeof(char*));
 //     int success_count = 0;
     
 //     if (strings) {
@@ -1576,10 +1576,10 @@
 //         // Nettoyer
 //         for (int i = 0; i < num_strings; i++) {
 //             if (strings[i]) {
-//                 free(strings[i]);
+//                 my_free(strings[i]);
 //             }
 //         }
-//         free(strings);
+//         my_free(strings);
 //     }
     
 //     // Test de fragmentation avec strdup
@@ -1593,7 +1593,7 @@
 //     // Libérer les chaînes impaires
 //     for (int i = 1; i < 50; i += 2) {
 //         if (frags[i]) {
-//             free(frags[i]);
+//             my_free(frags[i]);
 //             frags[i] = NULL;
 //         }
 //     }
@@ -1609,7 +1609,7 @@
 //     // Nettoyer la fragmentation
 //     for (int i = 0; i < 50; i++) {
 //         if (frags[i]) {
-//             free(frags[i]);
+//             my_free(frags[i]);
 //         }
 //     }
     
@@ -1635,14 +1635,14 @@
 //     if (empty_dup) {
 //         test_result(strlen(empty_dup) == 0, "strdup empty string length is 0");
 //         test_result(empty_dup[0] == '\0', "strdup empty string is properly terminated");
-//         free(empty_dup);
+//         my_free(empty_dup);
 //     }
 // }
 
 // void test_strdup_boundary_conditions() {
 //     TEST_SECTION("STRDUP BOUNDARY CONDITIONS");
     
-//     // Test exactement aux limites des catégories de malloc
+//     // Test exactement aux limites des catégories de my_malloc
     
 //     // Limite TINY: 128 bytes total, donc 127 chars + \0
 //     char tiny_boundary[128];
@@ -1655,11 +1655,11 @@
 //         test_result(strlen(tiny_dup) == 127, "strdup TINY boundary length correct");
 //         test_result(tiny_dup[126] == 'T' && tiny_dup[127] == '\0', 
 //                    "strdup TINY boundary termination correct");
-//         free(tiny_dup);
+//         my_free(tiny_dup);
 //     }
     
 //     // Limite SMALL: 1024 bytes total, donc 1023 chars + \0
-//     char *small_boundary = malloc(1024);
+//     char *small_boundary = my_malloc(1024);
 //     if (small_boundary) {
 //         memset(small_boundary, 'S', 1023);
 //         small_boundary[1023] = '\0';
@@ -1670,13 +1670,13 @@
 //             test_result(strlen(small_dup) == 1023, "strdup SMALL boundary length correct");
 //             test_result(small_dup[1022] == 'S' && small_dup[1023] == '\0', 
 //                        "strdup SMALL boundary termination correct");
-//             free(small_dup);
+//             my_free(small_dup);
 //         }
-//         free(small_boundary);
+//         my_free(small_boundary);
 //     }
     
 //     // Premier LARGE: 1025 bytes total, donc 1024 chars + \0
-//     char *large_boundary = malloc(1025);
+//     char *large_boundary = my_malloc(1025);
 //     if (large_boundary) {
 //         memset(large_boundary, 'L', 1024);
 //         large_boundary[1024] = '\0';
@@ -1687,14 +1687,14 @@
 //             test_result(strlen(large_dup) == 1024, "strdup LARGE boundary length correct");
 //             test_result(large_dup[1023] == 'L' && large_dup[1024] == '\0', 
 //                        "strdup LARGE boundary termination correct");
-//             free(large_dup);
+//             my_free(large_dup);
 //         }
-//         free(large_boundary);
+//         my_free(large_boundary);
 //     }
 // }
 
 // int main(void) {
-//     printf(YELLOW "Starting comprehensive malloc/realloc/free test suite...\n" RESET);
+//     printf(YELLOW "Starting comprehensive my_malloc/my_realloc/my_free test suite...\n" RESET);
     
 //     test_basic_malloc();
 //     test_small_malloc();
@@ -1716,7 +1716,7 @@
 //     test_calloc_patterns();
 //     test_calloc_extreme();
     
-//     // Tests reallocarray hardcore  
+//     // Tests my_reallocarray hardcore  
 //     test_reallocarray_basic();
 //     test_reallocarray_overflow();
 //     test_reallocarray_categories();
@@ -1808,8 +1808,8 @@ void* test_sequential_malloc(void* arg) {
     printf("Thread %d: Démarrage test séquentiel (%d allocations)\n", 
            data->thread_id, data->allocations_target);
     
-    data->allocated_ptrs = calloc(data->allocations_target, sizeof(void*));
-    data->allocated_sizes = calloc(data->allocations_target, sizeof(size_t));
+    data->allocated_ptrs = my_calloc(data->allocations_target, sizeof(void*));
+    data->allocated_sizes = my_calloc(data->allocations_target, sizeof(size_t));
     
     if (!data->allocated_ptrs || !data->allocated_sizes) {
         printf("Thread %d: Erreur allocation tableaux de suivi\n", data->thread_id);
@@ -1821,7 +1821,7 @@ void* test_sequential_malloc(void* arg) {
         size_t size = MIN_ALLOC_SIZE + (rand() % (MAX_ALLOC_SIZE - MIN_ALLOC_SIZE));
         
         // Allocation
-        void* ptr = malloc(size);
+        void* ptr = my_malloc(size);
         if (!ptr) {
             printf("Thread %d: Erreur allocation %zu bytes (allocation #%d)\n", 
                    data->thread_id, size, i);
@@ -1880,8 +1880,8 @@ void* test_rapid_malloc(void* arg) {
     
     printf("Thread %d: Démarrage test rapide\n", data->thread_id);
     
-    data->allocated_ptrs = calloc(data->allocations_target, sizeof(void*));
-    data->allocated_sizes = calloc(data->allocations_target, sizeof(size_t));
+    data->allocated_ptrs = my_calloc(data->allocations_target, sizeof(void*));
+    data->allocated_sizes = my_calloc(data->allocations_target, sizeof(size_t));
     
     // Tailles prédéfinies pour tester différents cas
     size_t test_sizes[] = {8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096};
@@ -1890,7 +1890,7 @@ void* test_rapid_malloc(void* arg) {
     for (int i = 0; i < data->allocations_target; i++) {
         size_t size = test_sizes[i % num_test_sizes];
         
-        void* ptr = malloc(size);
+        void* ptr = my_malloc(size);
         if (!ptr) {
             printf("Thread %d: Erreur allocation %zu bytes\n", data->thread_id, size);
             data->errors++;
@@ -1931,14 +1931,14 @@ void* test_delayed_verification(void* arg) {
     
     printf("Thread %d: Démarrage test avec vérification différée\n", data->thread_id);
     
-    data->allocated_ptrs = calloc(data->allocations_target, sizeof(void*));
-    data->allocated_sizes = calloc(data->allocations_target, sizeof(size_t));
+    data->allocated_ptrs = my_calloc(data->allocations_target, sizeof(void*));
+    data->allocated_sizes = my_calloc(data->allocations_target, sizeof(size_t));
     
     // Phase 1: Allocations rapides
     for (int i = 0; i < data->allocations_target; i++) {
         size_t size = MIN_ALLOC_SIZE + (rand() % (MAX_ALLOC_SIZE - MIN_ALLOC_SIZE));
         
-        void* ptr = malloc(size);
+        void* ptr = my_malloc(size);
         if (!ptr) {
             data->errors++;
             continue;
@@ -2001,14 +2001,14 @@ void* test_large_allocations(void* arg) {
     
     // Réduire le nombre pour les grandes allocations
     int large_alloc_count = data->allocations_target / 4;
-    data->allocated_ptrs = calloc(large_alloc_count, sizeof(void*));
-    data->allocated_sizes = calloc(large_alloc_count, sizeof(size_t));
+    data->allocated_ptrs = my_calloc(large_alloc_count, sizeof(void*));
+    data->allocated_sizes = my_calloc(large_alloc_count, sizeof(size_t));
     
     for (int i = 0; i < large_alloc_count; i++) {
         // Tailles entre 1KB et 16KB
         size_t size = 1024 + (rand() % (16 * 1024 - 1024));
         
-        void* ptr = malloc(size);
+        void* ptr = my_malloc(size);
         if (!ptr) {
             printf("Thread %d: Erreur allocation grande taille %zu bytes\n", 
                    data->thread_id, size);
@@ -2071,7 +2071,7 @@ void check_pointer_alignment(void** ptrs, int count, int thread_id) {
 }
 
 int main() {
-    printf("=== Test Multi-threadé pour malloc uniquement ===\n");
+    printf("=== Test Multi-threadé pour my_malloc uniquement ===\n");
     printf("Configuration: %d threads, %d allocations par thread\n", 
            NUM_THREADS, ALLOCATIONS_PER_THREAD);
     printf("Tailles: %d à %d bytes\n\n", MIN_ALLOC_SIZE, MAX_ALLOC_SIZE);
@@ -2158,24 +2158,24 @@ int main() {
                thread_data[i].errors + thread_data[i].write_errors + thread_data[i].read_errors);
     }
     
-    // Nettoyage (avec le free standard, pas le vôtre)
+    // Nettoyage (avec le my_free standard, pas le vôtre)
     for (int i = 0; i < NUM_THREADS; i++) {
         if (thread_data[i].allocated_ptrs) {
-            free(thread_data[i].allocated_ptrs);  // free standard
+            my_free(thread_data[i].allocated_ptrs);  // my_free standard
         }
         if (thread_data[i].allocated_sizes) {
-            free(thread_data[i].allocated_sizes);  // free standard
+            my_free(thread_data[i].allocated_sizes);  // my_free standard
         }
     }
     
 	// show_alloc_mem_ex();
     if (total_errors == 0) {
         printf("\n✅ TOUS LES TESTS SONT PASSÉS!\n");
-        printf("Votre malloc semble fonctionner correctement en multi-threading.\n");
+        printf("Votre my_malloc semble fonctionner correctement en multi-threading.\n");
         return 0;
     } else {
         printf("\n❌ %d ERREURS DÉTECTÉES\n", total_errors);
-        printf("Vérifiez la thread-safety de votre malloc.\n");
+        printf("Vérifiez la thread-safety de votre my_malloc.\n");
         return 1;
     }
 }

--- a/srcs/malloc.c
+++ b/srcs/malloc.c
@@ -1,7 +1,4 @@
 #include "../includes/malloc_internal.h"
-#include <pthread.h>
-#include <strings.h>
-#include <unistd.h>
 
 t_malloc g_malloc = {
 	{ NULL, NULL, PTHREAD_MUTEX_INITIALIZER },
@@ -138,7 +135,7 @@ bool	malloc_force_fail(size_t size)
 	if (g_malloc.fail_size != 1 && (int)size == g_malloc.fail_size)
 	{
 		ft_printf_fd(STDERR_FILENO,
-						"[DEBUG] malloc(size: %u) forced to fail!\n",
+						"[DEBUG] my_malloc(size: %u) forced to fail!\n",
 						size);
 		return (true);
 	}
@@ -162,7 +159,7 @@ void	*malloc_internal(size_t size)
 	return (ptr);
 }
 
-void	*malloc(size_t size)
+void	*my_malloc(size_t size)
 {
 	void	*ptr;
 
@@ -185,13 +182,13 @@ void	*malloc(size_t size)
 		pthread_mutex_unlock(&g_malloc.large.mutex);
 	if (g_malloc.verbose)
 	{
-		ft_printf_fd(STDERR_FILENO, "[DEBUG] malloc(%u) -> %p\n",
+		ft_printf_fd(STDERR_FILENO, "[DEBUG] my_malloc(%u) -> %p\n",
 				size, ptr);
 	}
 	if (g_malloc.trace_file_fd != -1)
 	{
 		ft_printf_fd(g_malloc.trace_file_fd,
-						"malloc(%u) -> %p\n",
+						"my_malloc(%u) -> %p\n",
 						size,
 						ptr);
 	}

--- a/srcs/reallocarray.c
+++ b/srcs/reallocarray.c
@@ -1,6 +1,6 @@
 #include "../includes/malloc_internal.h"
 
-void *reallocarray(void *ptr, size_t nmemb, size_t size) {
+void *my_reallocarray(void *ptr, size_t nmemb, size_t size) {
     void *new_ptr;
 
 	pthread_mutex_lock(&g_malloc_lock);
@@ -10,11 +10,11 @@ void *reallocarray(void *ptr, size_t nmemb, size_t size) {
     if (is_gonna_overflow(nmemb, size)) {
         if (g_malloc.verbose) {
             ft_printf_fd(STDERR_FILENO,
-                "[ERROR] reallocarray overflow detected\n\t-> nmemb: %u, size: %u (multiplication too large)\n", nmemb, size);
+                "[ERROR] my_reallocarray overflow detected\n\t-> nmemb: %u, size: %u (multiplication too large)\n", nmemb, size);
         }
         if (g_malloc.trace_file_fd != -1) {
 			ft_printf_fd(g_malloc.trace_file_fd,
-                "[ERROR] reallocarray overflow (nmemb: %u, size: %u)\n", nmemb, size);
+                "[ERROR] my_reallocarray overflow (nmemb: %u, size: %u)\n", nmemb, size);
         }
         return NULL;
     }
@@ -23,13 +23,13 @@ void *reallocarray(void *ptr, size_t nmemb, size_t size) {
 
     if (g_malloc.verbose) {
         ft_printf_fd(STDERR_FILENO,
-            "[DEBUG] reallocarray(ptr: %p, nmemb: %u, size: %u)\n\t-> allocated %u bytes at %p\n",
+            "[DEBUG] my_reallocarray(ptr: %p, nmemb: %u, size: %u)\n\t-> allocated %u bytes at %p\n",
             ptr, nmemb, size, nmemb * size, new_ptr);
     }
 
     if (g_malloc.trace_file_fd != -1) {
         ft_printf_fd(g_malloc.trace_file_fd,
-            "reallocarray(ptr: %p, nmemb: %u, size: %u) -> %p\n",
+            "my_reallocarray(ptr: %p, nmemb: %u, size: %u) -> %p\n",
             ptr, nmemb, size, new_ptr);
     }
 

--- a/srcs/show_alloc_mem_ex.c
+++ b/srcs/show_alloc_mem_ex.c
@@ -62,7 +62,7 @@ size_t	print_page_blocks_ex(t_page *page)
 			used_blocks++;
 		block = NEXT_BLOCK(block);
 	}
-	ft_printf_fd(STDERR_FILENO, "   -> Page stats: %u used, %u free\n",
+	ft_printf_fd(STDERR_FILENO, "   -> Page stats: %u used, %u my_free\n",
 			used_blocks, free_blocks);
 	return (total_size);
 }

--- a/srcs/strdup.c
+++ b/srcs/strdup.c
@@ -10,7 +10,7 @@ char	*strdup_internal(const char *s)
 	dest = malloc_internal(len + 1);
 	if (dest == NULL)
 		return (dest);
-	return (strcpy(dest, s));
+	return (memmove(dest, s, len + 1));
 }
 
 char *strdup(const char *s)

--- a/todo.txt
+++ b/todo.txt
@@ -1,6 +1,2 @@
-faire en sorte que malloc soit thread-safe
-
 gerer la variable d'environement qui permettent de changer le taille des zones
 gerer la variable d'environement qui permettent de changer le nombre de zones
-
-voir si c'est possible de faire une liste chaine de block free


### PR DESCRIPTION
PR: Refactor Free List Management
Summary

This PR refactors the free list implementation to improve block management performance and consistency. Instead of using a single forward-linked list, the free list is now managed as a doubly linked list with explicit head and last pointers.

Key Changes

t_block

Changed size type from unsigned int to size_t (better portability, avoids overflow).

Added next_free and prev_free pointers for doubly linked free list support.

Simplified block traversal and removal logic.

t_free_list

Introduced head and last pointers for O(1) insertion and efficient list management.

t_page

Embedded t_free_list structure for each page.

Block merging

Reworked block_merge_with_next and block_merge_with_prev to maintain correct free list linkage when adjacent blocks are merged.

Free list operations

add_block_to_free_list: O(1) append at the end of the list.

remove_block_free_list: Properly removes a block from the middle, head, or tail in O(1).

Benefits

Faster allocation and free operations.

More efficient block merging during defragmentation.

Cleaner separation of concerns (t_free_list manages list pointers explicitly).

Improved maintainability of the allocator.